### PR TITLE
Pass loop attribute to asyncio.ensure_future

### DIFF
--- a/mode/worker.py
+++ b/mode/worker.py
@@ -269,7 +269,10 @@ class Worker(Service):
         self._starting_fut = None
         with exiting(file=self.stderr):
             try:
-                self._starting_fut = asyncio.ensure_future(self.start())
+                self._starting_fut = asyncio.ensure_future(
+                    self.start(),
+                    loop=self.loop,
+                )
                 self.loop.run_until_complete(self._starting_fut)
             except asyncio.CancelledError:
                 pass

--- a/t/unit/test_worker.py
+++ b/t/unit/test_worker.py
@@ -254,7 +254,7 @@ class test_Worker:
                 worker.execute_from_commandline()
             assert excinfo.value.code == 0
             assert worker._starting_fut is ensure_future.return_value
-            ensure_future.assert_called_once_with(worker.start.return_value)
+            ensure_future.assert_called_once_with(worker.start.return_value, worker.loop)
             worker.stop_and_shutdown.assert_called_once_with()
 
     def test_execute_from_commandline__MemoryError(self, worker):


### PR DESCRIPTION
If we specify a custom event loop at worker instantiation, it has to also be used by asyncio instead of default one.

## Description

In some situation (for example in integration tests of Faust agents), I have to retry worker startup because kafka is not yet available.

But the first time I run `execute_from_commandline`, the default event loop is closed so I have to create a new one before calling `execute_from_commandline` again.

Unfortunately, custom event loop is not properly transmitted to asyncio, so it automatically makes use of default event loop and raise a `RuntimeError('Event loop is closed')`.

With this simple fix, user-specified event loop will be properly transmitted to asyncio.