### PR TITLE
Fix sleep twice before execution and update `timer` function signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Documentation/
 .project
 .pydevproject
 .idea/
+.vscode/
 .coverage
 .ve*
 cover/


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.fauststream.com/en/master/contributing.html).

## Description

Original implementation will cause twice sleep function calls before first execution, like:

```python
await sleep(1.0)
await sleep(1.0)
await func()
await sleep(1.0)
await func()
```

So I remove redundant first sleep function, the behavior is the same with `Faust` ([code link](https://github.com/faust-streaming/faust/blob/60a869654d1e13914d36f3db0c66fef28911c7ce/faust/app/base.py#L1014)). And also add argument to decide whether to execute first call before timer (default is set to `False`).

PS: extra unit tests has passed.
