### PR TITLE
install runtime dependencies when building pages to get metadata

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+    - name: "Install runtime dependencies in order to get package metadata"
+      run: "scripts/install"
     - name: "Install deps and build with Sphinx"
       run: make docs
     - name: "Upload artifacts"


### PR DESCRIPTION
This should fix the failing GitHub Pages builds.