### PR TITLE
Fix passing coroutine objects to `wait()`

### DIFF
--- a/mode/__init__.py
+++ b/mode/__init__.py
@@ -1,16 +1,29 @@
 # -*- coding: utf-8 -*-
 """AsyncIO Service-based programming."""
 # :copyright: (c) 2017-2020, Robinhood Markets
+#             (c) 2020-2022, faust-streaming Org
 #             All rights reserved.
 # :license:   BSD (3 Clause), see LICENSE for more details.
 import re
 import sys
-import typing
+from typing import NamedTuple
 
-# Lazy loading.
-# - See werkzeug/__init__.py for the rationale behind this.
-from types import ModuleType  # noqa
-from typing import Any, Mapping, NamedTuple, Sequence
+from .services import Service, task, timer  # noqa: E402
+from .signals import BaseSignal, Signal, SyncSignal  # noqa: E402
+from .supervisors import CrashingSupervisor  # noqa: E402
+from .supervisors import (
+    ForfeitOneForAllSupervisor,
+    ForfeitOneForOneSupervisor,
+    OneForAllSupervisor,
+    OneForOneSupervisor,
+    SupervisorStrategy,
+)
+from .types.services import ServiceT  # noqa: E402
+from .types.signals import BaseSignalT, SignalT, SyncSignalT  # noqa: E402
+from .types.supervisors import SupervisorStrategyT  # noqa: E402
+from .utils.logging import flight_recorder, get_logger, setup_logging  # noqa: E402
+from .utils.objects import label, shortlabel  # noqa: E402
+from .utils.times import Seconds, want_seconds
 
 if sys.version_info < (3, 8):
     from importlib_metadata import version
@@ -18,7 +31,7 @@ else:
     from importlib.metadata import version
 
 __version__ = version("mode-streaming")
-__author__ = "Robinhood Markets"
+__author__ = "Faust Streaming"
 __contact__ = "vpatki@wayfair.com, williambbarnhart@gmail.com"
 __homepage__ = "https://github.com/faust-streaming/mode"
 __docformat__ = "restructuredtext"
@@ -46,138 +59,3 @@ VERSION = version_info = version_info_t(
 del _match
 del _temp
 del re
-
-if sys.version_info <= (3, 7):  # pragma: no cover
-    import aiocontextvars  # noqa
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    from .services import Service, task, timer  # noqa: E402
-    from .signals import BaseSignal, Signal, SyncSignal  # noqa: E402
-    from .supervisors import CrashingSupervisor  # noqa: E402
-    from .supervisors import (
-        ForfeitOneForAllSupervisor,
-        ForfeitOneForOneSupervisor,
-        OneForAllSupervisor,
-        OneForOneSupervisor,
-        SupervisorStrategy,
-    )
-    from .types.services import ServiceT  # noqa: E402
-    from .types.signals import BaseSignalT, SignalT, SyncSignalT  # noqa: E402
-    from .types.supervisors import SupervisorStrategyT  # noqa: E402
-    from .utils.logging import flight_recorder, get_logger, setup_logging  # noqa: E402
-    from .utils.objects import label, shortlabel  # noqa: E402
-    from .utils.times import Seconds, want_seconds  # noqa: E402
-    from .worker import Worker  # noqa: E402
-
-__all__ = [
-    "BaseSignal",
-    "BaseSignalT",
-    "Service",
-    "Signal",
-    "SignalT",
-    "SyncSignal",
-    "SyncSignalT",
-    "ForfeitOneForAllSupervisor",
-    "ForfeitOneForOneSupervisor",
-    "OneForAllSupervisor",
-    "OneForOneSupervisor",
-    "SupervisorStrategy",
-    "CrashingSupervisor",
-    "ServiceT",
-    "SupervisorStrategyT",
-    "Seconds",
-    "want_seconds",
-    "get_logger",
-    "setup_logging",
-    "label",
-    "shortlabel",
-    "Worker",
-    "task",
-    "timer",
-    "flight_recorder",
-]
-
-
-all_by_module: Mapping[str, Sequence[str]] = {
-    "mode.services": ["Service", "task", "timer"],
-    "mode.signals": ["BaseSignal", "Signal", "SyncSignal"],
-    "mode.supervisors": [
-        "ForfeitOneForAllSupervisor",
-        "ForfeitOneForOneSupervisor",
-        "OneForAllSupervisor",
-        "OneForOneSupervisor",
-        "SupervisorStrategy",
-        "CrashingSupervisor",
-    ],
-    "mode.types.services": ["ServiceT"],
-    "mode.types.signals": ["BaseSignalT", "SignalT", "SyncSignalT"],
-    "mode.types.supervisors": ["SupervisorStrategyT"],
-    "mode.utils.times": ["Seconds", "want_seconds"],
-    "mode.utils.logging": ["flight_recorder", "get_logger", "setup_logging"],
-    "mode.utils.objects": ["label", "shortlabel"],
-    "mode.worker": ["Worker"],
-}
-
-object_origins = {}
-for module, items in all_by_module.items():
-    for item in items:
-        object_origins[item] = module
-
-
-class _module(ModuleType):
-    """Customized Python module."""
-
-    def __getattr__(self, name: str) -> Any:
-        if name in object_origins:
-            module = __import__(object_origins[name], None, None, [name])
-            for extra_name in all_by_module[module.__name__]:
-                setattr(self, extra_name, getattr(module, extra_name))
-            return getattr(module, name)
-        return ModuleType.__getattribute__(self, name)
-
-    def __dir__(self) -> Sequence[str]:
-        result = list(new_module.__all__)
-        result.extend(
-            (
-                "__file__",
-                "__path__",
-                "__doc__",
-                "__all__",
-                "__docformat__",
-                "__name__",
-                "__path__",
-                "VERSION",
-                "version_info_t",
-                "version_info",
-                "__package__",
-                "__version__",
-                "__author__",
-                "__contact__",
-                "__homepage__",
-                "__docformat__",
-            )
-        )
-        return result
-
-
-# keep a reference to this module so that it's not garbage collected
-old_module = sys.modules[__name__]
-
-new_module = sys.modules[__name__] = _module(__name__)
-new_module.__dict__.update(
-    {
-        "__file__": __file__,
-        "__path__": __path__,  # type: ignore
-        "__doc__": __doc__,
-        "__all__": tuple(object_origins),
-        "__version__": __version__,
-        "__author__": __author__,
-        "__contact__": __contact__,
-        "__homepage__": __homepage__,
-        "__docformat__": __docformat__,
-        "__package__": __package__,
-        "version_info_t": version_info_t,
-        "version_info": version_info,
-        "VERSION": VERSION,
-    }
-)

--- a/mode/loop/_gevent_loop.py
+++ b/mode/loop/_gevent_loop.py
@@ -12,6 +12,6 @@ class Loop(gevent.core.loop):  # type: ignore
 
     def run_callback(self, *args: Any, **kwargs: Any) -> None:
         if self._aioloop_loop is None:
-            self._aioloop_loop = asyncio.get_event_loop()
+            self._aioloop_loop = asyncio.get_event_loop_policy().get_event_loop()
         gevent.spawn_later(0.0, self._aioloop_loop._run_once)  # type: ignore
         super().run_callback(*args, **kwargs)

--- a/mode/loop/gevent.py
+++ b/mode/loop/gevent.py
@@ -55,4 +55,4 @@ class Policy(aiogevent.EventLoopPolicy):  # type: ignore
 
 policy = Policy()
 asyncio.set_event_loop_policy(policy)
-loop = asyncio.get_event_loop()
+loop = asyncio.get_event_loop_policy().get_event_loop()

--- a/mode/threads.py
+++ b/mode/threads.py
@@ -104,11 +104,12 @@ class ServiceThread(Service):
         **kwargs: Any,
     ) -> None:
         # cannot share loop between threads, so create a new one
-        assert asyncio.get_event_loop()
         if executor is not None:
             raise NotImplementedError("executor argument no longer supported")
-        self.parent_loop = loop or asyncio.get_event_loop()
-        self.thread_loop = thread_loop or asyncio.new_event_loop()
+        self.parent_loop = loop or asyncio.get_event_loop_policy().get_event_loop()
+        self.thread_loop = (
+            thread_loop or asyncio.get_event_loop_policy().new_event_loop()
+        )
         self._thread_started = Event(loop=self.parent_loop)
         if Worker is not None:
             self.Worker = Worker
@@ -195,7 +196,7 @@ class ServiceThread(Service):
 
     async def crash(self, exc: BaseException) -> None:
         # <- .start() will raise
-        if asyncio.get_event_loop() is self.parent_loop:
+        if asyncio.get_event_loop_policy().get_event_loop() is self.parent_loop:
             maybe_set_exception(self._thread_running, exc)
         else:
             self.parent_loop.call_soon_threadsafe(

--- a/mode/threads.py
+++ b/mode/threads.py
@@ -10,6 +10,7 @@ import asyncio
 import sys
 import threading
 import traceback
+from asyncio.locks import Event
 from time import monotonic
 from typing import (
     Any,
@@ -25,7 +26,6 @@ from typing import (
 
 from .services import Service
 from .utils.futures import maybe_async, maybe_set_exception, maybe_set_result, notify
-from .utils.locks import Event
 
 __all__ = [
     "QueuedMethod",
@@ -110,12 +110,10 @@ class ServiceThread(Service):
         self.thread_loop = (
             thread_loop or asyncio.get_event_loop_policy().new_event_loop()
         )
-        self._thread_started = Event(loop=self.parent_loop)
+        self._thread_started = Event()
         if Worker is not None:
             self.Worker = Worker
         super().__init__(loop=self.thread_loop, **kwargs)
-        assert self._shutdown.loop is self.parent_loop
-        assert self._stopped.loop is self.thread_loop
 
     async def on_thread_started(self) -> None:
         ...
@@ -150,7 +148,7 @@ class ServiceThread(Service):
     #      thread calls _shutdown.set(), parent calls _shutdown.wait()
 
     def _new_shutdown_event(self) -> Event:
-        return Event(loop=self.parent_loop)
+        return Event()
 
     async def maybe_start(self) -> bool:
         if not self._thread_started.is_set():
@@ -324,7 +322,7 @@ class MethodQueue(Service):
     def __init__(self, num_workers: int = 2, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._queue = asyncio.Queue()
-        self._queue_ready = Event(loop=self.loop)
+        self._queue_ready = Event()
         self.num_workers = num_workers
         self._workers = []
 

--- a/mode/utils/futures.py
+++ b/mode/utils/futures.py
@@ -122,7 +122,7 @@ def done_future(
     result: Any = None, *, loop: asyncio.AbstractEventLoop = None
 ) -> asyncio.Future:
     """Return :class:`asyncio.Future` that is already evaluated."""
-    f = (loop or asyncio.get_event_loop()).create_future()
+    f = (loop or asyncio.get_event_loop_policy().get_event_loop()).create_future()
     f.set_result(result)
     return f
 

--- a/mode/utils/locks.py
+++ b/mode/utils/locks.py
@@ -82,5 +82,5 @@ class Event:
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         if self._loop is None:
-            self._loop = asyncio.get_event_loop()
+            self._loop = asyncio.get_event_loop_policy().get_event_loop()
         return self._loop

--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -541,7 +541,7 @@ def cry(
         thread = tmap.get(tid)
         if thread:
             if thread.ident == current_thread.ident:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_event_loop_policy().get_event_loop()
             else:
                 loop = getattr(thread, "loop", None)
             print(f"THREAD {thread.name}", file=file)  # noqa: T003
@@ -669,7 +669,7 @@ class flight_recorder(ContextManager, LogSeverityMixin):
         self.id = next(self._id_source)
         self.logger = logger
         self.timeout = want_seconds(timeout)
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop or asyncio.get_event_loop_policy().get_event_loop()
         self.started_at_date = None
         self.enabled_by = None
         self.exit_stack = ExitStack()

--- a/mode/utils/mocks.py
+++ b/mode/utils/mocks.py
@@ -1,49 +1,21 @@
 """Mocking and testing utilities."""
-import asyncio
+from typing import Any, Iterator, cast
+
 import builtins
 import sys
 import types
 import unittest.mock
 from contextlib import contextmanager
-from itertools import count
 from types import ModuleType
-from typing import (
-    Any,
-    Callable,
-    ContextManager,
-    Iterator,
-    List,
-    Optional,
-    Type,
-    Union,
-    cast,
-)
+from unittest.mock import MagicMock
 
-# from asyncio import coroutine  ## or from types import coroutine
-
-__all__ = [
-    "ANY",
-    "IN",
-    "AsyncMagicMock",
-    "AsyncMock",
-    "AsyncContextMock",
-    "ContextMock",
-    "FutureMock",
-    "MagicMock",
-    "Mock",
-    "call",
-    "mask_module",
-    "patch",
-    "patch_module",
-]
-
-MOCK_CALL_COUNT = count(0)
+__all__ = ["IN", "call", "mask_module", "patch_module"]
 
 
 class IN:
     """Class used to check for multiple alternatives.
 
-    .. sourcecode:: python
+    .. code-block:: python
 
         assert foo.value IN(a, b)
 
@@ -63,178 +35,8 @@ class IN:
         return f"<IN: {sep.join(map(str, self.alternatives))}>"
 
 
-class Mock(unittest.mock.Mock):
-    """Mock object."""
-
-    global_call_count: Optional[int] = None
-    call_counts: List[int] = cast(List[int], None)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        ret = super().__call__(*args, **kwargs)
-        count = self.global_call_count = next(MOCK_CALL_COUNT)
-        if self.call_counts is None:
-            # mypy thinks this is unreachable as we mask that this is Optional
-            self.call_counts = [count]  # type: ignore
-        else:
-            self.call_counts.append(count)
-        return ret
-
-    def reset_mock(self, *args: Any, **kwargs: Any) -> None:
-        super().reset_mock(*args, **kwargs)
-        if self.call_counts is not None:
-            self.call_counts.clear()
-
-
-class _ContextMock(Mock, ContextManager):
-    """Internal context mock class.
-
-    Dummy class implementing __enter__ and __exit__
-    as the :keyword:`with` statement requires these to be implemented
-    in the class, not just the instance.
-    """
-
-    def __enter__(self) -> "_ContextMock":
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Type[BaseException] = None,
-        exc_val: BaseException = None,
-        exc_tb: types.TracebackType = None,
-    ) -> Optional[bool]:
-        pass
-
-
-def ContextMock(*args: Any, **kwargs: Any) -> _ContextMock:
-    """Mock that mocks :keyword:`with` statement contexts."""
-    obj = _ContextMock(*args, **kwargs)
-    obj.attach_mock(_ContextMock(), "__enter__")
-    obj.attach_mock(_ContextMock(), "__exit__")
-    obj.__enter__.return_value = obj  # type: ignore
-    # if __exit__ return a value the exception is ignored,
-    # so it must return None here.
-    obj.__exit__.return_value = None  # type: ignore
-    return obj
-
-
-class AsyncMock(unittest.mock.Mock):
-    """Mock for ``async def`` function/method or anything awaitable."""
-
-    def __init__(self, *args: Any, name: str = None, **kwargs: Any) -> None:
-        super().__init__(name=name)
-        coro = Mock(*args, **kwargs)
-        self.attach_mock(coro, "coro")
-        self.side_effect = coroutine(coro)
-
-
-class AsyncMagicMock(unittest.mock.MagicMock):
-    """A magic mock type for ``async def`` functions/methods."""
-
-    def __init__(self, *args: Any, name: str = None, **kwargs: Any) -> None:
-        super().__init__(name=name)
-        coro = MagicMock(*args, **kwargs)
-        self.attach_mock(coro, "coro")
-        self.side_effect = coroutine(coro)
-
-
-class AsyncContextMock(unittest.mock.Mock):
-    """Mock for :class:`typing.AsyncContextManager`.
-
-    You can use this to mock asynchronous context managers,
-    when an object with a fully defined ``__aenter__`` and ``__aexit__``
-    is required.
-
-    Here's an example mocking an :pypi:`aiohttp` client:
-
-    .. code-block:: python
-
-        import http
-        from aiohttp.client import ClientSession
-        from aiohttp.web import Response
-        from mode.utils.mocks import AsyncContextManagerMock, AsyncMock, Mock
-
-        @pytest.fixture()
-        def session(monkeypatch):
-            session = Mock(
-                name='http_client',
-                autospec=ClientSession,
-                request=Mock(
-                    return_value=AsyncContextManagerMock(
-                        return_value=Mock(
-                            autospec=Response,
-                            status=http.HTTPStatus.OK,
-                            json=AsyncMock(
-                                return_value={'hello': 'json'},
-                            ),
-                        ),
-                    ),
-                ),
-            )
-            monkeypatch.setattr('where.is.ClientSession', session)
-            return session
-
-        @pytest.mark.asyncio
-        async def test_session(session):
-            from where.is import ClientSession
-            session = ClientSession()
-            async with session.get('http://example.com') as response:
-                assert response.status == http.HTTPStatus.OK
-                assert await response.json() == {'hello': 'json'}
-    """
-
-    def __init__(
-        self,
-        *args: Any,
-        aenter_return: Any = None,
-        aexit_return: Any = None,
-        side_effect: Union[Callable, BaseException] = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.aenter_return = aenter_return
-        self.aexit_return = aexit_return
-        self.side_effect = side_effect
-
-    async def __aenter__(self) -> Any:
-        mgr = self.aenter_return or self.return_value
-        if self.side_effect:
-            if isinstance(self.side_effect, BaseException):
-                raise self.side_effect
-            else:
-                return self.side_effect()
-        if isinstance(mgr, AsyncMock):
-            return mgr.coro
-        return mgr
-
-    async def __aexit__(self, *args: Any) -> Any:
-        return self.aexit_return
-
-
-AsyncContextManagerMock = AsyncContextMock  # XXX compat alias
-
-
-class FutureMock(unittest.mock.Mock):
-    """Mock a :class:`asyncio.Future`."""
-
-    awaited = False
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._loop = asyncio.get_event_loop()
-
-    def __await__(self) -> Any:
-        self.awaited = True
-        yield self()
-
-    def assert_awaited(self) -> None:
-        assert self.awaited
-
-    def assert_not_awaited(self) -> None:
-        assert not self.awaited
-
-
 @contextmanager
-def patch_module(*names: str, new_callable: Any = Mock) -> Iterator:
+def patch_module(*names: str, new_callable: Any = MagicMock) -> Iterator:
     """Mock one or modules such that every attribute is a :class:`Mock`."""
     prev = {}
 
@@ -300,11 +102,6 @@ def mask_module(*modnames: str) -> Iterator:
         builtins.__import__ = realimport
 
 
-ANY = unittest.mock.ANY
-
-MagicMock = unittest.mock.MagicMock
-
-
 class _Call(unittest.mock._Call):
     # Fixes bug in Python 3.8 where call is an instance of unittest.mock._Call
     # but call.__doc__ returns a mocked method and not the class attribute.
@@ -316,5 +113,3 @@ class _Call(unittest.mock._Call):
 
 
 call = _Call(from_kall=False)
-
-patch = unittest.mock.patch

--- a/mode/utils/mocks.py
+++ b/mode/utils/mocks.py
@@ -4,7 +4,6 @@ import builtins
 import sys
 import types
 import unittest.mock
-from asyncio import coroutine
 from contextlib import contextmanager
 from itertools import count
 from types import ModuleType
@@ -19,6 +18,8 @@ from typing import (
     Union,
     cast,
 )
+
+# from asyncio import coroutine  ## or from types import coroutine
 
 __all__ = [
     "ANY",

--- a/mode/utils/mocks.py
+++ b/mode/utils/mocks.py
@@ -1,12 +1,11 @@
 """Mocking and testing utilities."""
-from typing import Any, Iterator, cast
-
 import builtins
 import sys
 import types
 import unittest.mock
 from contextlib import contextmanager
 from types import ModuleType
+from typing import Any, Iterator, cast
 from unittest.mock import MagicMock
 
 __all__ = ["IN", "call", "mask_module", "patch_module"]

--- a/mode/utils/queues.py
+++ b/mode/utils/queues.py
@@ -2,11 +2,11 @@
 import asyncio
 import math
 import typing
+from asyncio.locks import Event
 from collections import deque
 from typing import Any, Callable, List, Set, TypeVar, cast, no_type_check
 from weakref import WeakSet
 
-from .locks import Event
 from .objects import cached_property
 from .typing import Deque
 
@@ -60,8 +60,8 @@ class FlowControlEvent:
         loop: asyncio.AbstractEventLoop = None
     ) -> None:
         self.loop = loop
-        self._resume = Event(loop=self.loop)
-        self._suspend = Event(loop=self.loop)
+        self._resume = Event()
+        self._suspend = Event()
         if initially_suspended:
             self._suspend.set()
         self._queues = WeakSet()

--- a/mode/utils/text.py
+++ b/mode/utils/text.py
@@ -1,11 +1,12 @@
 """Text and string manipulation utilities."""
 from difflib import SequenceMatcher
-from typing import AnyStr, Iterable, Iterator, NamedTuple, Optional
-
-from .compat import want_str
+from typing import IO, AnyStr, Iterable, Iterator, NamedTuple, Optional
 
 __all__ = [
     "FuzzyMatch",
+    "want_bytes",
+    "want_str",
+    "isatty",
     "title",
     "didyoumean",
     "fuzzymatch_choices",
@@ -25,6 +26,32 @@ class FuzzyMatch(NamedTuple):
 
     ratio: float
     value: str
+
+
+def want_bytes(s: AnyStr) -> bytes:
+    """Convert string to bytes."""
+    if isinstance(s, str):
+        return s.encode()
+    return s
+
+
+def want_str(s: AnyStr) -> str:
+    """Convert bytes to string."""
+    if isinstance(s, bytes):
+        return s.decode()
+    return s
+
+
+def isatty(fh: IO) -> bool:
+    """Return True if fh has a controlling terminal.
+
+    Notes:
+        Use with e.g. :data:`sys.stdin`.
+    """
+    try:
+        return fh.isatty()
+    except AttributeError:
+        return False
 
 
 def title(s: str) -> str:

--- a/t/functional/test_proxy.py
+++ b/t/functional/test_proxy.py
@@ -1,8 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock, Mock
+
 import pytest
 
 from mode import Service, label, shortlabel
 from mode.proxy import ServiceProxy
-from mode.utils.mocks import AsyncMock, MagicMock, Mock
 
 
 class Proxy(ServiceProxy):
@@ -47,15 +48,15 @@ class test_Proxy:
     @pytest.mark.asyncio
     async def test_add_runtime_dependency(self, *, proxy, service, subservice):
         ret = await proxy.add_runtime_dependency(subservice)
-        service.add_runtime_dependency.assert_called_once_with(subservice)
-        assert ret is service.add_runtime_dependency.coro()
+        service.add_runtime_dependency.assert_awaited_once_with(subservice)
+        assert ret is service.add_runtime_dependency.return_value
 
     @pytest.mark.asyncio
     async def test_add_async_context(self, *, proxy, service):
         context = MagicMock()
         ret = await proxy.add_async_context(context)
-        service.add_async_context.assert_called_once_with(context)
-        assert ret is service.add_async_context.coro()
+        service.add_async_context.assert_awaited_once_with(context)
+        assert ret is service.add_async_context.return_value
 
     def test_add_context(self, *, proxy, service):
         context = MagicMock()
@@ -66,19 +67,19 @@ class test_Proxy:
     @pytest.mark.asyncio
     async def test_start(self, *, proxy, service):
         await proxy.start()
-        service.start.assert_called_once_with()
+        service.start.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_maybe_start(self, *, proxy, service):
-        service.maybe_start.coro.return_value = False
+        service.maybe_start.return_value = False
         assert not await proxy.maybe_start()
-        service.maybe_start.assert_called_once_with()
+        service.maybe_start.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_crash(self, *, proxy, service):
         exc = KeyError()
         await proxy.crash(exc)
-        service.crash.assert_called_once_with(exc)
+        service.crash.assert_awaited_once_with(exc)
 
     def test__crash(self, *, proxy, service):
         exc = KeyError()
@@ -88,7 +89,7 @@ class test_Proxy:
     @pytest.mark.asyncio
     async def test_stop(self, *, proxy, service):
         await proxy.stop()
-        service.stop.assert_called_once_with()
+        service.stop.assert_awaited_once_with()
 
     def test_service_reset(self, *, proxy, service):
         proxy.service_reset()
@@ -97,12 +98,12 @@ class test_Proxy:
     @pytest.mark.asyncio
     async def test_restart(self, *, proxy, service):
         await proxy.restart()
-        service.restart.assert_called_once_with()
+        service.restart.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_wait_until_stopped(self, *, proxy, service):
         await proxy.wait_until_stopped()
-        service.wait_until_stopped.assert_called_once_with()
+        service.wait_until_stopped.assert_awaited_once_with()
 
     def test_set_shutdown(self, *, proxy, service):
         proxy.set_shutdown()

--- a/t/functional/test_service.py
+++ b/t/functional/test_service.py
@@ -1,8 +1,7 @@
-from typing import AsyncContextManager, ContextManager
-
 import asyncio
 import logging
 from asyncio.locks import Event
+from typing import AsyncContextManager, ContextManager
 from unittest.mock import Mock
 
 import pytest

--- a/t/functional/test_service.py
+++ b/t/functional/test_service.py
@@ -1,13 +1,13 @@
+from typing import AsyncContextManager, ContextManager
+
 import asyncio
 import logging
-from typing import ContextManager
+from asyncio.locks import Event
+from unittest.mock import Mock
 
 import pytest
 
 import mode
-from mode.utils.locks import Event
-from mode.utils.mocks import Mock
-from mode.utils.typing import AsyncContextManager
 
 
 class X(mode.Service):

--- a/t/functional/test_signals.py
+++ b/t/functional/test_signals.py
@@ -1,11 +1,12 @@
 from typing import Any
+
+from unittest.mock import Mock
 from weakref import ref
 
 import pytest
 
 from mode import label
 from mode.signals import Signal, SignalT, SyncSignal, SyncSignalT
-from mode.utils.mocks import Mock
 
 
 class X:

--- a/t/functional/test_signals.py
+++ b/t/functional/test_signals.py
@@ -1,5 +1,4 @@
 from typing import Any
-
 from unittest.mock import Mock
 from weakref import ref
 

--- a/t/functional/test_timers.py
+++ b/t/functional/test_timers.py
@@ -1,9 +1,8 @@
-from typing import List, NamedTuple, Tuple
-
 import asyncio
 from contextlib import asynccontextmanager
 from functools import reduce
 from itertools import chain
+from typing import List, NamedTuple, Tuple
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest

--- a/t/functional/test_timers.py
+++ b/t/functional/test_timers.py
@@ -1,14 +1,15 @@
+from typing import List, NamedTuple, Tuple
+
 import asyncio
+from contextlib import asynccontextmanager
 from functools import reduce
 from itertools import chain
-from typing import List, NamedTuple, Tuple
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 
 from mode.timers import Timer
 from mode.utils.aiter import aslice
-from mode.utils.contexts import asynccontextmanager
-from mode.utils.mocks import ANY, AsyncMock, Mock, patch
 
 
 @pytest.mark.asyncio

--- a/t/functional/utils/test_aiter.py
+++ b/t/functional/utils/test_aiter.py
@@ -2,7 +2,15 @@ from typing import AsyncIterable
 
 import pytest
 
-from mode.utils.aiter import aenumerate, aiter, alist, anext, arange, aslice, chunks
+from mode.utils.aiter import (
+    aenumerate,
+    aiter,
+    alist,
+    anext,
+    arange,
+    aslice,
+    chunks,
+)
 
 
 class AIT(AsyncIterable):

--- a/t/functional/utils/test_aiter.py
+++ b/t/functional/utils/test_aiter.py
@@ -2,15 +2,7 @@ from typing import AsyncIterable
 
 import pytest
 
-from mode.utils.aiter import (
-    aenumerate,
-    aiter,
-    alist,
-    anext,
-    arange,
-    aslice,
-    chunks,
-)
+from mode.utils.aiter import aenumerate, aiter, alist, anext, arange, aslice, chunks
 
 
 class AIT(AsyncIterable):

--- a/t/functional/utils/test_collections.py
+++ b/t/functional/utils/test_collections.py
@@ -1,4 +1,5 @@
 import pickle
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -13,7 +14,6 @@ from mode.utils.collections import (
     ManagedUserSet,
     force_mapping,
 )
-from mode.utils.mocks import Mock, call, patch
 
 
 class test_FastUserDict:

--- a/t/functional/utils/test_compat.py
+++ b/t/functional/utils/test_compat.py
@@ -1,7 +1,8 @@
+from unittest.mock import Mock
+
 import pytest
 
 from mode.utils.compat import isatty, want_bytes, want_str
-from mode.utils.mocks import Mock
 
 
 @pytest.mark.parametrize(

--- a/t/functional/utils/test_futures.py
+++ b/t/functional/utils/test_futures.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from unittest.mock import Mock
 
 import pytest
 
@@ -12,7 +13,6 @@ from mode.utils.futures import (
     maybe_set_result,
     stampede,
 )
-from mode.utils.mocks import Mock
 
 
 class X:
@@ -144,7 +144,7 @@ class test_StampedeWrapper:
 
 @pytest.mark.asyncio
 async def test_maybe_set_exception():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     future = loop.create_future()
     maybe_set_exception(future, KeyError())
     with pytest.raises(KeyError):
@@ -157,7 +157,7 @@ async def test_maybe_set_exception():
 
 @pytest.mark.asyncio
 async def test_maybe_set_result():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     future = loop.create_future()
     maybe_set_result(future, 42)
     assert future.result() == 42

--- a/t/functional/utils/test_queues.py
+++ b/t/functional/utils/test_queues.py
@@ -1,10 +1,10 @@
 import asyncio
 from time import monotonic
 
+from unittest.mock import Mock
 import pytest
 
 from mode.utils.futures import done_future
-from mode.utils.mocks import Mock
 from mode.utils.queues import FlowControlEvent, FlowControlQueue, ThrowableQueue
 
 

--- a/t/functional/utils/test_queues.py
+++ b/t/functional/utils/test_queues.py
@@ -1,7 +1,7 @@
 import asyncio
 from time import monotonic
-
 from unittest.mock import Mock
+
 import pytest
 
 from mode.utils.futures import done_future

--- a/t/functional/utils/test_text.py
+++ b/t/functional/utils/test_text.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from mode.utils import text
@@ -79,7 +81,12 @@ def test_fuzzymatch_best(choices, choice, expected):
 @pytest.mark.parametrize(
     "origin,name,prefix,expected",
     [
-        ("examples.simple", "examples.simple.Withdrawal", "[...]", "[...]Withdrawal"),
+        (
+            "examples.simple",
+            "examples.simple.Withdrawal",
+            "[...]",
+            "[...]Withdrawal",
+        ),
         (
             "examples.other",
             "examples.simple.Withdrawal",
@@ -124,7 +131,10 @@ def test_maybecat(s, prefix, suffix, expected):
 @pytest.mark.parametrize(
     "s,expected",
     [
-        ("faust.utils.transformators.frobster", "faust.utils.transform[.]frobster"),
+        (
+            "faust.utils.transformators.frobster",
+            "faust.utils.transform[.]frobster",
+        ),
         ("foo.bar.baz", "foo.bar.baz"),
         (
             "foobarbazdeliciouslybubblyfluffychocolatebar",
@@ -134,3 +144,33 @@ def test_maybecat(s, prefix, suffix, expected):
 )
 def test_shorten_fqdn(s, expected):
     assert text.shorten_fqdn(s) == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("foo", b"foo"),
+        (b"foo", b"foo"),
+    ],
+)
+def test_want_bytes(input, expected):
+    assert text.want_bytes(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (b"foo", "foo"),
+        ("foo", "foo"),
+    ],
+)
+def test_want_str(input, expected):
+    assert text.want_str(input) == expected
+
+
+def test_isatty():
+    m = Mock()
+    m.isatty.return_value = True
+    assert text.isatty(m)
+    m.isatty.side_effect = AttributeError()
+    assert not text.isatty(m)

--- a/t/functional/utils/test_times.py
+++ b/t/functional/utils/test_times.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import timedelta
+from datetime import timedelta, datetime
 from time import monotonic
 
 import pytest
@@ -27,11 +27,19 @@ from mode.utils.times import (
         ("1333/d", 0.01542824074074074),
         (1, 1),
         (timedelta(seconds=1.234), 1.234),
-        (None, None),
     ],
 )
 def test_want_seconds(input, expected):
     assert want_seconds(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input",
+    (None, datetime.now()),
+)
+def test_want_seconds__unexpected_types(input):
+    with pytest.raises(TypeError):
+        want_seconds(input)
 
 
 @pytest.mark.parametrize(

--- a/t/functional/utils/test_times.py
+++ b/t/functional/utils/test_times.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from time import monotonic
 
 import pytest

--- a/t/functional/utils/test_times.py
+++ b/t/functional/utils/test_times.py
@@ -34,15 +34,6 @@ def test_want_seconds(input, expected):
 
 
 @pytest.mark.parametrize(
-    "input",
-    (None, datetime.now()),
-)
-def test_want_seconds__unexpected_types(input):
-    with pytest.raises(TypeError):
-        want_seconds(input)
-
-
-@pytest.mark.parametrize(
     "input,expected",
     [
         (10.1, 10.1),

--- a/t/functional/utils/test_tracebacks.py
+++ b/t/functional/utils/test_tracebacks.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from mode.utils.mocks import Mock, patch
+from unittest.mock import Mock, patch
 from mode.utils.tracebacks import Traceback, format_task_stack
 
 
@@ -17,16 +17,15 @@ async def test_format_task_stack():
     async def bar():
         await baz()
 
-    @asyncio.coroutine
-    def baz():
+    async def baz():
         task = asyncio.ensure_future(xuz())
-        yield from asyncio.sleep(0.1)
+        await asyncio.sleep(0.1)
         for _ in range(100):
             assert format_task_stack(task, limit=0)
             assert format_task_stack(task, limit=-300)
             assert format_task_stack(task, limit=None)
             assert format_task_stack(task, limit=3, capture_locals=True)
-        yield from on_done.wait()
+        await on_done.wait()
 
     async def xuz():
         await xuz1()
@@ -50,9 +49,8 @@ async def test_format_task_stack():
     await asyncio.sleep(0.05)
     assert format_task_stack(task, limit=None)
 
-    @asyncio.coroutine
-    def moo():
-        yield from asyncio.sleep(0.1)
+    async def moo():
+        await asyncio.sleep(0.1)
 
     task = asyncio.ensure_future(moo())
     await asyncio.sleep(0.05)

--- a/t/functional/utils/test_tracebacks.py
+++ b/t/functional/utils/test_tracebacks.py
@@ -1,8 +1,8 @@
 import asyncio
+from unittest.mock import Mock, patch
 
 import pytest
 
-from unittest.mock import Mock, patch
 from mode.utils.tracebacks import Traceback, format_task_stack
 
 

--- a/t/unit/test_debug.py
+++ b/t/unit/test_debug.py
@@ -1,10 +1,10 @@
 import signal
 import sys
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from mode.debug import Blocking, BlockingDetector
-from mode.utils.mocks import AsyncMock, Mock, patch
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="win32: no SIGALRM")
@@ -21,7 +21,7 @@ class test_BlockingDetector:
         def on_sleep(*args, **kwargs):
             block._stopped.set()
 
-        block.sleep.coro.side_effect = on_sleep
+        block.sleep.side_effect = on_sleep
         await block._deadman_switch(block)
 
     def test_reset_signal(self, block):

--- a/t/unit/test_locals.py
+++ b/t/unit/test_locals.py
@@ -1,7 +1,6 @@
-import abc
-import sys
 from typing import (
     AbstractSet,
+    AsyncGenerator,
     AsyncIterable,
     AsyncIterator,
     Awaitable,
@@ -11,6 +10,10 @@ from typing import (
     MutableSet,
     Sequence,
 )
+
+import abc
+import sys
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -32,8 +35,6 @@ from mode.locals import (
     SetProxy,
     maybe_evaluate,
 )
-from mode.utils.mocks import MagicMock, Mock
-from mode.utils.typing import AsyncGenerator
 
 
 class test_Proxy:

--- a/t/unit/test_locals.py
+++ b/t/unit/test_locals.py
@@ -1,3 +1,5 @@
+import abc
+import sys
 from typing import (
     AbstractSet,
     AsyncGenerator,
@@ -10,9 +12,6 @@ from typing import (
     MutableSet,
     Sequence,
 )
-
-import abc
-import sys
 from unittest.mock import MagicMock, Mock
 
 import pytest

--- a/t/unit/test_services.py
+++ b/t/unit/test_services.py
@@ -1,7 +1,6 @@
-from typing import AsyncContextManager, ContextManager
-
 import asyncio
 from functools import partial
+from typing import AsyncContextManager, ContextManager
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 import pytest

--- a/t/unit/test_services.py
+++ b/t/unit/test_services.py
@@ -1,22 +1,14 @@
+from typing import AsyncContextManager, ContextManager
+
 import asyncio
 from functools import partial
-from typing import ContextManager
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
 
 from mode import Service
 from mode.services import Diag, ServiceTask, WaitResult
 from mode.utils.logging import get_logger
-from mode.utils.mocks import (
-    ANY,
-    AsyncContextManagerMock,
-    AsyncMock,
-    ContextMock,
-    Mock,
-    call,
-    patch,
-)
-from mode.utils.typing import AsyncContextManager
 
 
 class S(Service):
@@ -59,8 +51,8 @@ class test_ServiceTask:
     async def test_call(self, *, task):
         obj = Mock()
         ret = await task(obj)
-        assert ret is task.fun.coro.return_value
-        task.fun.coro.assert_called_once_with(obj)
+        assert ret is task.fun.return_value
+        task.fun.assert_awaited_once_with(obj)
 
     def test_repr(self, *, task):
         assert repr(task) == repr(task.fun)
@@ -106,7 +98,6 @@ async def test_aenter():
 @pytest.mark.asyncio
 async def test_interface():
     s = Service()
-    s.on_init()
     s.__post_init__()
     await s.on_start()
     await s.on_stop()
@@ -202,10 +193,10 @@ class test_Service:
                     self._stopped.set()
 
         async def itertimer(*args, **kwargs):
+            yield 0.1
+            yield 0.2
             yield 0.3
             yield 0.4
-            yield 0.5
-            yield 0.6
 
         foo = Foo()
         foo.sleep = AsyncMock()
@@ -316,7 +307,7 @@ class test_Service:
         service._started.set()
         await service.add_runtime_dependency(s2)
         service.add_dependency.assert_called_once_with(s2)
-        s2.maybe_start.coro.assert_called_once_with()
+        s2.maybe_start.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_add_runtime_dependency__not_started(self, *, service):
@@ -333,7 +324,7 @@ class test_Service:
         service.add_dependency(s2)
         service._started.set()
         await service.remove_dependency(s2)
-        s2.stop.coro.assert_called_once_with()
+        s2.stop.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_remove_dependency__no_beacon(self, *, service):
@@ -377,18 +368,31 @@ class test_Service:
         service._stopped = Mock()
         service._crashed = Mock()
 
-        with patch("asyncio.wait", AsyncMock()) as wait:
+        with (
+            patch("asyncio.wait", AsyncMock()) as wait,
+            patch("asyncio.ensure_future", Mock()) as ensure_future,
+        ):
             f1 = Mock()
             f2 = Mock()
             f3 = Mock()
-            done, pending = wait.coro.return_value = ((f1,), (f2, f3))
+            done, pending = wait.return_value = ((f1,), (f2, f3))
 
             await service._wait_stopped(timeout=1.0)
-            wait.assert_called_once_with(
+
+            service._stopped.wait.assert_called_once()
+            service._crashed.wait.assert_called_once()
+
+            ensure_future.assert_has_calls(
                 [
-                    service._stopped.wait.return_value,
-                    service._crashed.wait.return_value,
-                ],
+                    call(service._stopped.wait.return_value, loop=service.loop),
+                    call(service._crashed.wait.return_value, loop=service.loop),
+                ]
+            )
+
+            stopped = ensure_future.return_value
+            crashed = ensure_future.return_value
+            wait.assert_called_once_with(
+                [stopped, crashed],
                 return_when=asyncio.FIRST_COMPLETED,
                 timeout=1.0,
             )
@@ -405,7 +409,7 @@ class test_Service:
         s1 = Mock()
         s2 = Mock()
         self._mock_for_start(service, init_deps=[s1, s2])
-        service.on_first_start.coro.side_effect = service._stopped.set
+        service.on_first_start.side_effect = service._stopped.set
         await service._actually_start()
         service.add_dependency.assert_has_calls([call(s1), call(s2)])
 
@@ -427,7 +431,7 @@ class test_Service:
             service,
             init_deps=[s1],
         )
-        service.on_start.coro.side_effect = service._stopped.set
+        service.on_start.side_effect = service._stopped.set
         service.restart_count = 1
         await service._actually_start()
 
@@ -438,7 +442,7 @@ class test_Service:
             service,
             init_deps=[s1],
         )
-        service.on_start.coro.side_effect = KeyError("foo")
+        service.on_start.side_effect = KeyError("foo")
         service.restart_count = 1
         with pytest.raises(KeyError):
             await service._actually_start()
@@ -450,7 +454,7 @@ class test_Service:
             service,
         )
         service._children = [s1]
-        s1.maybe_start.coro.side_effect = service._stopped.set
+        s1.maybe_start.side_effect = service._stopped.set
         service.restart_count = 1
         await service._actually_start()
 
@@ -461,7 +465,7 @@ class test_Service:
             service,
         )
         service._children = [None, s1]
-        s1.maybe_start.coro.side_effect = service._stopped.set
+        s1.maybe_start.side_effect = service._stopped.set
         service.restart_count = 1
         await service._actually_start()
 
@@ -471,8 +475,8 @@ class test_Service:
         service.on_init_dependencies = Mock(return_value=init_deps or [])
         service.add_dependency = Mock()
         service.on_first_start = AsyncMock()
-        service.exit_stack = ContextMock()
-        service.async_exit_stack = AsyncContextManagerMock(
+        service.exit_stack = MagicMock()
+        service.async_exit_stack = AsyncMock(
             side_effect=on_async_enter,
         )
         service.on_start = AsyncMock()
@@ -484,22 +488,22 @@ class test_Service:
         s1 = Mock(maybe_start=AsyncMock(), stop=AsyncMock())
         s2 = Mock(maybe_start=AsyncMock(), stop=AsyncMock())
         await service.join_services([s1, s2])
-        s1.maybe_start.coro.assert_called_once_with()
-        s2.maybe_start.coro.assert_called_once_with()
-        s1.stop.coro.assert_called_once_with()
-        s2.stop.coro.assert_called_once_with()
+        s1.maybe_start.assert_awaited_once_with()
+        s2.maybe_start.assert_awaited_once_with()
+        s1.stop.assert_awaited_once_with()
+        s2.stop.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_join_services_raises(self, *, service):
         s1 = Mock(maybe_start=AsyncMock(), stop=AsyncMock())
-        s1.maybe_start.coro.side_effect = KeyError()
+        s1.maybe_start.side_effect = KeyError()
         service.crash = AsyncMock()
         s2 = Mock(maybe_start=AsyncMock(), stop=AsyncMock())
         await service.join_services([s1, s2])
-        s1.maybe_start.coro.assert_called_once_with()
-        s2.maybe_start.coro.assert_called_once_with()
-        s1.stop.coro.assert_called_once_with()
-        s2.stop.coro.assert_called_once_with()
+        s1.maybe_start.assert_awaited_once_with()
+        s2.maybe_start.assert_awaited_once_with()
+        s1.stop.assert_awaited_once_with()
+        s2.stop.assert_awaited_once_with()
 
     def test_init_subclass_logger(self, *, service):
         class X(Service):
@@ -544,7 +548,7 @@ class test_Service:
             raise exc
 
         await service._execute_task(raises())
-        service.crash.coro.assert_called_once_with(exc)
+        service.crash.assert_awaited_once_with(exc)
 
     @pytest.mark.asyncio
     async def test__execute_task__RuntimeError(self, *, service):
@@ -555,7 +559,7 @@ class test_Service:
             raise exc
 
         await service._execute_task(raises())
-        service.crash.coro.assert_called_once_with(exc)
+        service.crash.assert_awaited_once_with(exc)
 
     @pytest.mark.asyncio
     async def test__execute_task__CancelledError(self, *, service):
@@ -577,32 +581,38 @@ class test_Service:
     async def test_wait__no_args(self, *, service):
         service._wait_stopped = AsyncMock()
         assert await service.wait(timeout=1.13) == WaitResult(None, True)
-        service._wait_stopped.coro.assert_called_once_with(timeout=1.13)
+        service._wait_stopped.assert_awaited_once_with(timeout=1.13)
 
     @pytest.mark.asyncio
     async def test_wait__one(self, *, service):
         service._wait_one = AsyncMock()
         coro = Mock()
         ret = await service.wait(coro, timeout=1.14)
-        assert ret is service._wait_one.coro.return_value
-        service._wait_one.assert_called_once_with(coro, timeout=1.14)
+        assert ret is service._wait_one.return_value
+        service._wait_one.assert_awaited_once_with(coro, timeout=1.14)
 
     @pytest.mark.asyncio
     async def test_wait_many(self, *, service):
-        with patch("asyncio.wait", AsyncMock()) as wait:
+        with (
+            patch("asyncio.wait", AsyncMock()) as wait,
+            patch("asyncio.ensure_future", Mock()) as ensure_future,
+        ):
             service._wait_one = AsyncMock()
             m1 = AsyncMock()
             m2 = AsyncMock()
             res = await service.wait_many([m1, m2], timeout=3.34)
-            assert res is service._wait_one.coro.return_value
+            assert res is service._wait_one.return_value
 
+            ensure_future.assert_has_calls(
+                [call(m1, loop=service.loop), call(m2, loop=service.loop)]
+            )
             wait.assert_called_once_with(
-                [m1, m2],
+                [ensure_future.return_value, ensure_future.return_value],
                 return_when=asyncio.ALL_COMPLETED,
                 timeout=3.34,
             )
 
-            service._wait_one.assert_called_once_with(ANY, timeout=3.34)
+            service._wait_one.assert_awaited_once_with(ANY, timeout=3.34)
 
     @pytest.mark.asyncio
     async def test_wait_first__propagates_exceptions(self, *, service):
@@ -612,7 +622,7 @@ class test_Service:
         m1.exception.return_value = exc
         m1.result.side_effect = exc
         with patch("asyncio.wait", AsyncMock()) as wait:
-            wait.coro.return_value = ((m1,), ())
+            wait.return_value = ((m1,), ())
             with pytest.raises(KeyError):
                 await service.wait_first(asyncio.sleep(5), timeout=5)
 
@@ -629,7 +639,7 @@ class test_Service:
                 fut.done.return_value = False
                 fut.cancelled.return_value = True
                 with patch("asyncio.wait", AsyncMock()) as wait:
-                    wait.coro.return_value = ((m1,), ())
+                    wait.return_value = ((m1,), ())
                     with pytest.raises(asyncio.CancelledError):
                         await service.wait_first(sleep, timeout=5)
 
@@ -717,11 +727,11 @@ class test_Service:
                 service._futures.clear()
             raise asyncio.CancelledError()
 
-        service._maybe_wait_for_futures.coro.side_effect = on_wait_for_futures
+        service._maybe_wait_for_futures.side_effect = on_wait_for_futures
 
         await service._gather_futures()
 
-        assert service._maybe_wait_for_futures.call_count == 3
+        assert service._maybe_wait_for_futures.await_count == 3
 
     @pytest.mark.asyncio
     async def test__maybe_wait_for_futures__ValueError_left(self, *, service):
@@ -735,7 +745,7 @@ class test_Service:
                     await fut
                     raise ValueError()
 
-                shield.coro.side_effect = on_shield
+                shield.side_effect = on_shield
                 with pytest.raises(ValueError):
                     await service._maybe_wait_for_futures()
 
@@ -767,7 +777,7 @@ class test_Service:
                     await fut
                     raise asyncio.CancelledError()
 
-                shield.coro.side_effect = on_shield
+                shield.side_effect = on_shield
                 await service._maybe_wait_for_futures()
 
     @pytest.mark.asyncio
@@ -818,7 +828,7 @@ class test_Service:
             values = [value async for value in service.itertimer(1.0)]
 
             assert values == []
-            service.sleep.assert_called_once()
+            service.sleep.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_itertimer__third_stop(self, *, service):

--- a/t/unit/test_threads.py
+++ b/t/unit/test_threads.py
@@ -1,12 +1,12 @@
 import asyncio
 import threading
+from asyncio.locks import Event
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 
 from mode.threads import MethodQueue, QueueServiceThread, ServiceThread, WorkerThread
 from mode.utils.futures import done_future
-from mode.utils.locks import Event
-from mode.utils.mocks import ANY, AsyncMock, Mock, patch
 
 
 class test_WorkerThread:
@@ -53,7 +53,7 @@ class test_ServiceThread:
 
     @pytest.fixture
     def Worker(self):
-        return Mock(name="Worker")
+        return Mock(spec=WorkerThread, name="Worker")
 
     @pytest.fixture
     def thread(self, *, Worker, loop, thread_loop):
@@ -63,12 +63,8 @@ class test_ServiceThread:
     async def test_on_thread_stop(self, *, thread):
         await thread.on_thread_stop()
 
-    def test_constructor_executor_deprecated(self):
-        with pytest.raises(NotImplementedError):
-            ServiceThread(executor=Mock())
-
     def test_constructor_worker_argument(self):
-        Worker = Mock()
+        Worker = Mock(spec=WorkerThread)
         assert ServiceThread(Worker=Worker).Worker is Worker
         assert ServiceThread(Worker=None).Worker
 
@@ -82,11 +78,11 @@ class test_ServiceThread:
         thread.start = AsyncMock(name="start")
         thread._thread_started.set()
         await thread.maybe_start()
-        thread.start.assert_not_called()
+        thread.start.assert_not_awaited()
 
         thread._thread_started.clear()
         await thread.maybe_start()
-        thread.start.assert_called_once_with()
+        thread.start.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_start(self, *, event_loop, thread):
@@ -103,7 +99,7 @@ class test_ServiceThread:
 
     @pytest.mark.asyncio
     async def test_start__no_wait(self, *, event_loop, thread):
-        thread.add_future = AsyncMock(name="thread.add_future")
+        thread.add_future = Mock(name="thread.add_future")
         thread.wait_for_thread = False
         thread._thread_running = None
         assert thread.parent_loop == event_loop
@@ -116,8 +112,13 @@ class test_ServiceThread:
         assert thread._thread_started.is_set()
 
     async def _wait_for_event(self, thread):
+        count = 0
         while thread._thread_running is None:
             await asyncio.sleep(0.1)
+            count += 1
+            if count >= 10:  # fast fail to avoid block tests
+                raise RuntimeError("Test failed")
+
         if not thread._thread_running.done():
             thread._thread_running.set_result(None)
 
@@ -169,9 +170,9 @@ class test_ServiceThread:
         thread._default_stop_futures = AsyncMock(name="stop_futures")
         await thread._shutdown_thread()
 
-        thread._default_stop_children.assert_called_once_with()
-        thread.on_thread_stop.assert_called_once_with()
-        thread._default_stop_futures.assert_called_once_with()
+        thread._default_stop_children.assert_awaited_once()
+        thread.on_thread_stop.assert_awaited_once()
+        thread._default_stop_futures.assert_awaited_once()
         thread._shutdown.is_set()
 
         thread._thread = Mock()
@@ -193,9 +194,9 @@ class test_ServiceThread:
         self.mock_for_serve(thread)
         await thread._serve()
 
-        thread._default_start.assert_called_once_with()
-        thread.wait_until_stopped.assert_called_once_with()
-        thread._shutdown_thread.assert_called_once_with()
+        thread._default_start.assert_awaited_once()
+        thread.wait_until_stopped.assert_awaited_once()
+        thread._shutdown_thread.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_serve__CancelledError(self, *, thread):
@@ -204,8 +205,9 @@ class test_ServiceThread:
 
         with pytest.raises(asyncio.CancelledError):
             await thread._serve()
+
         thread.crash.assert_not_called()
-        thread._shutdown_thread.assert_called_once_with()
+        thread._shutdown_thread.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_serve__Exception(self, *, thread):
@@ -215,8 +217,8 @@ class test_ServiceThread:
         with pytest.raises(KeyError):
             await thread._serve()
 
-        thread.crash.assert_called_once_with(exc)
-        thread._shutdown_thread.assert_called_once_with()
+        thread.crash.assert_awaited_once_with(exc)
+        thread._shutdown_thread.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_serve__Exception_no_beacon(self, *, thread):
@@ -227,8 +229,8 @@ class test_ServiceThread:
         with pytest.raises(KeyError):
             await thread._serve()
 
-        thread.crash.assert_called_once_with(exc)
-        thread._shutdown_thread.assert_called_once_with()
+        thread.crash.assert_awaited_once_with(exc)
+        thread._shutdown_thread.assert_awaited_once_with()
 
     def mock_for_serve(self, thread):
         thread._default_start = AsyncMock(name="start")
@@ -259,7 +261,7 @@ class test_ServiceThread:
 class test_MethodQueue:
     @pytest.mark.asyncio
     async def test_call(self):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_event_loop_policy().get_event_loop()
         queue = MethodQueue(num_workers=2)
 
         async with queue:
@@ -278,7 +280,7 @@ class test_MethodQueue:
 
     @pytest.mark.asyncio
     async def test_call_raising(self):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_event_loop_policy().get_event_loop()
         queue = MethodQueue(num_workers=2)
         all_done = asyncio.Event()
         calls = 0
@@ -358,7 +360,7 @@ class test_QueueServiceThread:
     async def test_on_thread_started(self, *, s):
         s._method_queue = Mock(start=AsyncMock())
         await s.on_thread_started()
-        s._method_queue.start.coro.assert_called_once_with()
+        s._method_queue.start.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_on_thread_stop(self, *, s):
@@ -366,7 +368,7 @@ class test_QueueServiceThread:
         await s.on_thread_stop()
         s._method_queue = Mock(stop=AsyncMock())
         await s.on_thread_stop()
-        s._method_queue.stop.coro.assert_called_once_with()
+        s._method_queue.stop.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_call_thread(self, *, s):
@@ -395,7 +397,7 @@ class test_QueueServiceThread:
         fun = Mock()
         s._method_queue = Mock(cast=AsyncMock())
         await s.cast_thread(fun, "arg1", "arg2", kw1=1, kw2=2)
-        s._method_queue.cast.coro.assert_called_once_with(
+        s._method_queue.cast.assert_awaited_once_with(
             fun,
             "arg1",
             "arg2",

--- a/t/unit/test_worker.py
+++ b/t/unit/test_worker.py
@@ -2,7 +2,7 @@ import signal
 import sys
 from contextlib import contextmanager
 from signal import Signals
-from unittest.mock import AsyncMock, patch, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 

--- a/t/unit/test_worker.py
+++ b/t/unit/test_worker.py
@@ -1,14 +1,14 @@
-import asyncio
 import signal
 import sys
 from contextlib import contextmanager
 from signal import Signals
+from unittest.mock import AsyncMock, patch, Mock
 
 import pytest
 
 from mode import Service
 from mode.debug import BlockingDetector
-from mode.utils.mocks import AsyncMock, Mock, call, mask_module, patch, patch_module
+from mode.utils.mocks import call, mask_module, patch_module
 from mode.worker import Worker, exiting
 
 
@@ -24,7 +24,7 @@ def test_exiting():
 class test_Worker:
     @pytest.fixture()
     def worker(self):
-        return Worker(loglevel="INFO", logfile=None)
+        return Worker(log_level="INFO", log_file=None)
 
     def setup_method(self, method):
         self.setup_logging_patch = patch("mode.utils.logging.setup_logging")
@@ -83,13 +83,13 @@ class test_Worker:
 
         await worker.on_first_start()
         worker._setup_logging.assert_called_once_with()
-        worker.on_execute.coro.assert_called_once_with()
+        worker.on_execute.assert_awaited_once_with()
         worker._add_monitor.assert_not_called()
         worker.install_signal_handlers.assert_called_once_with()
 
         worker.debug = True
         await worker.on_first_start()
-        worker._add_monitor.coro.assert_called_once_with()
+        worker._add_monitor.assert_awaited_once_with()
 
     @pytest.mark.asyncio
     async def test_on_first_start__override_logging(self):
@@ -97,14 +97,14 @@ class test_Worker:
         self._setup_for_on_first_start(worker)
         await worker.on_first_start()
 
-        worker._setup_logging.assert_not_called()
+        worker._setup_logging.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_on_execute(self, worker):
         await worker.on_execute()
 
     @pytest.mark.parametrize(
-        "loghandlers",
+        "log_handlers",
         [
             [],
             [Mock(), Mock()],
@@ -112,19 +112,19 @@ class test_Worker:
             None,
         ],
     )
-    def test_setup_logging(self, loghandlers):
+    def test_setup_logging(self, log_handlers):
         worker_inst = Worker(
-            loglevel=5,
-            logfile="TEMP",
+            log_level=5,
+            log_file="TEMP",
+            log_handlers=log_handlers,
             logging_config=None,
-            loghandlers=loghandlers,
         )
         worker_inst._setup_logging()
         self.setup_logging.assert_called_once_with(
-            loglevel=5,
-            logfile="TEMP",
+            log_level=5,
+            log_file="TEMP",
+            log_handlers=log_handlers or [],
             logging_config=None,
-            loghandlers=loghandlers or [],
         )
 
     def test_setup_logging_raises_exception(self, worker):
@@ -144,32 +144,16 @@ class test_Worker:
         with patch("mode.utils.logging.setup_logging"):
             worker._setup_logging()
 
-    def test_stop_and_shutdown(self, worker):
-        worker.loop = Mock()
-        worker.stop = Mock()
-        worker._signal_stop_future = None
-        worker._stopped.set()
-        worker._shutdown_loop = Mock()
-
-        worker.stop_and_shutdown()
-        worker._shutdown_loop.assert_called_once_with()
-
-        worker._signal_stop_future = Mock()
-        worker._signal_stop_future.done.return_value = False
-        worker.stop_and_shutdown()
-
-        worker.loop.run_until_complete.assert_called_with(worker._signal_stop_future)
-
     @pytest.mark.asyncio
     async def test_maybe_start_blockdetection(self, worker):
         worker._blocking_detector = Mock(maybe_start=AsyncMock())
         worker.debug = False
         await worker.maybe_start_blockdetection()
-        worker._blocking_detector.maybe_start.assert_not_called()
+        worker._blocking_detector.maybe_start.assert_not_awaited()
 
         worker.debug = True
         await worker.maybe_start_blockdetection()
-        worker._blocking_detector.maybe_start.coro.assert_called_once_with()
+        worker._blocking_detector.maybe_start.assert_awaited_once_with()
 
     def test_instal_signal_handlers(self, worker):
         worker._install_signal_handlers_windows = Mock()
@@ -242,61 +226,98 @@ class test_Worker:
     async def test__stop_on_signal(self, worker):
         worker.stop = AsyncMock()
         await worker._stop_on_signal(Signals.SIGTERM)
-        worker.stop.coro.assert_called_once_with()
+        worker.stop.assert_awaited_once()
 
     def test_execute_from_commandline(self, worker):
+
         with self.patch_execute(worker) as ensure_future:
             with pytest.raises(SystemExit) as excinfo:
                 worker.execute_from_commandline()
+
             assert excinfo.value.code == 0
+
             assert worker._starting_fut is ensure_future.return_value
             ensure_future.assert_called_once_with(
                 worker.start.return_value, loop=worker.loop
             )
-            worker.stop_and_shutdown.assert_called_once_with()
+            worker.loop.run_until_complete.assert_called_once_with(
+                worker.join.return_value
+            )
+            worker._shutdown_loop.assert_called_once_with()
 
-    def test_execute_from_commandline__MemoryError(self, worker):
-        with self.patch_execute(worker):
-            worker.start.side_effect = MemoryError()
-            with pytest.raises(SystemExit) as excinfo:
-                worker.execute_from_commandline()
-            assert excinfo.value.code > 0
+    # def test_join__MemoryError(self, worker):
+    #     with self.patch_execute(worker):
+    #         worker.join.side_effect = MemoryError()
+    #         with pytest.raises(SystemExit) as excinfo:
+    #             worker.execute_from_commandline()
+    #         assert excinfo.value.code > 0
 
-    def test_execute_from_commandline__CancelledError(self, worker):
-        with self.patch_execute(worker):
-            worker.start.side_effect = asyncio.CancelledError()
-            with pytest.raises(SystemExit) as excinfo:
-                worker.execute_from_commandline()
-            assert excinfo.value.code == 0
+    # def test_join__MemoryError(self, worker):
+    #     with self.patch_execute(worker):
+    #         worker.join.side_effect = MemoryError()
+    #         with pytest.raises(SystemExit) as excinfo:
+    #             worker.execute_from_commandline()
+    #         assert excinfo.value.code > 0
 
-    def test_execute_from_commandline__Exception(self, worker):
-        with self.patch_execute(worker):
-            worker.start.side_effect = KeyError("foo")
-            with pytest.raises(SystemExit) as excinfo:
-                worker.execute_from_commandline()
-            assert excinfo.value.code > 0
+    # def test_join__CancelledError(self, worker):
+    #     with self.patch_execute(worker):
+    #         worker.join.side_effect = asyncio.CancelledError()
+    #         with pytest.raises(SystemExit) as excinfo:
+    #             worker.execute_from_commandline()
+    #         assert excinfo.value.code == 0
+
+    # def test_join__Exception(self, worker):
+    #     with self.patch_execute(worker):
+    #         worker.join.side_effect = KeyError("foo")
+    #         with pytest.raises(SystemExit) as excinfo:
+    #             worker.execute_from_commandline()
+    #         assert excinfo.value.code > 0
 
     @contextmanager
     def patch_execute(self, worker):
-        worker.loop = Mock()
+        worker.join = Mock()
         worker.start = Mock()
-        worker.stop_and_shutdown = Mock()
+        worker.loop = Mock()
+        worker._shutdown_loop = Mock()
         with patch("asyncio.ensure_future") as ensure_future:
             yield ensure_future
 
-    def test_on_worker_shutdown(self, worker):
-        worker.on_worker_shutdown()
+    # @pytest.mark.asyncio
+    # async def test_join__stop_and_shutdown(self, worker):
+    #     worker._starting_fut = AsyncMock()
+    #     worker.on_worker_shutdown = AsyncMock()
+    #     worker.stop_and_shutdown = AsyncMock()
 
-    def test_stop_and_shutdown__stopping_worker(self, worker):
-        worker.loop = Mock()
-        worker.stop = Mock()
-        worker._shutdown_loop = Mock()
+    #     await worker.join()
+
+    #     worker.on_worker_shutdown.assert_awaited_once()
+    #     worker.stop_and_shutdown.assert_awaited_once()
+
+    # @pytest.mark.asyncio
+    # async def test_stop_and_shutdown(self, worker):
+    #     worker.stop = AsyncMock()
+    #     worker._gather_all_after_stop = AsyncMock()
+    #     worker._stopped.set()
+
+    #     worker._signal_stop_future = Mock(
+    #         done=Mock(return_value=False), __await__=AsyncMock()
+    #     )
+
+    #     assert worker._signal_stop_future.done() == False
+    #     await worker.stop_and_shutdown()
+    #     worker._signal_stop_future.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_and_shutdown__stopping_worker(self, worker):
+
+        worker.stop = AsyncMock()
         worker._signal_stop_future = None
         worker._stopped.clear()
-        worker.loop = Mock()
-        worker.stop_and_shutdown()
+        worker._gather_all_after_stop = AsyncMock()
 
-        worker.loop.run_until_complete.assert_called_with(worker.stop.return_value)
+        await worker.stop_and_shutdown()
+
+        worker.stop.assert_awaited_once()
 
     def test__shutdown_loop(self, worker):
         with self.patch_shutdown_loop(worker, is_running=False):
@@ -346,29 +367,30 @@ class test_Worker:
         worker._gather_futures = Mock()
         worker._gather_all = Mock()
         worker.loop.is_running.return_value = is_running
-        worker._sentinel_task = Mock()
+        worker._sentinel_task = AsyncMock()
         with patch("asyncio.ensure_future") as ensure_future:
-            with patch("asyncio.sleep"):
+            with patch("asyncio.sleep", AsyncMock()):
                 yield ensure_future
 
     @pytest.mark.asyncio
     async def test__sentinel_task(self, worker):
         with patch("asyncio.sleep", AsyncMock()) as sleep:
             await worker._sentinel_task()
-            sleep.coro.assert_called_once_with(1.0)
+            sleep.assert_called_once_with(1.0)
 
-    def test__gather_all(self, worker):
+    @pytest.mark.asyncio
+    async def test__gather_all(self, worker):
         with patch("mode.worker.all_tasks") as all_tasks:
-            with patch("asyncio.sleep"):
+            with patch("asyncio.sleep", AsyncMock()):
                 all_tasks.return_value = [Mock(), Mock(), Mock()]
-                worker.loop = Mock()
 
-                worker._gather_all()
+                await worker._gather_all()
 
                 for task in all_tasks.return_value:
                     task.cancel.assert_called_once_with()
 
-    def test__gather_all_early(self, worker):
+    @pytest.mark.asyncio
+    async def test__gather_all_early(self, worker):
         with patch("mode.worker.all_tasks") as all_tasks:
             with patch("asyncio.sleep"):
                 worker.loop = Mock()
@@ -380,7 +402,7 @@ class test_Worker:
 
                 all_tasks.side_effect = on_all_tasks
 
-                worker._gather_all()
+                await worker._gather_all()
 
                 for task in all_tasks.return_value:
                     task.cancel.assert_called_once_with()
@@ -390,10 +412,10 @@ class test_Worker:
         worker.daemon = False
         worker.wait_until_stopped = AsyncMock()
         await worker.on_started()
-        worker.wait_until_stopped.assert_not_called()
+        worker.wait_until_stopped.assert_not_awaited()
         worker.daemon = True
         await worker.on_started()
-        worker.wait_until_stopped.coro.assert_called_once()
+        worker.wait_until_stopped.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test__add_monitor(self, worker):

--- a/t/unit/utils/test_cron.py
+++ b/t/unit/utils/test_cron.py
@@ -1,4 +1,5 @@
-import pytz
+from zoneinfo import ZoneInfo
+
 from freezegun import freeze_time
 
 from mode.utils.cron import secs_for_next
@@ -24,7 +25,7 @@ def test_secs_for_next():
 
 @freeze_time("2000-01-01 00:00:00")
 def test_secs_for_next_with_tz():
-    pacific = pytz.timezone("US/Pacific")
+    pacific = ZoneInfo("US/Pacific")
 
     every_8pm_cron_format = "0 20 * * *"
     # In Pacific time it's 16:00 so only 4 hours until 8:00pm

--- a/t/unit/utils/test_cron.py
+++ b/t/unit/utils/test_cron.py
@@ -1,4 +1,13 @@
-from zoneinfo import ZoneInfo
+import sys
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+
+    make_tz = ZoneInfo
+else:
+    import pytz
+
+    make_tz = pytz.timezone
 
 from freezegun import freeze_time
 
@@ -25,7 +34,7 @@ def test_secs_for_next():
 
 @freeze_time("2000-01-01 00:00:00")
 def test_secs_for_next_with_tz():
-    pacific = ZoneInfo("US/Pacific")
+    pacific = make_tz("US/Pacific")
 
     every_8pm_cron_format = "0 20 * * *"
     # In Pacific time it's 16:00 so only 4 hours until 8:00pm

--- a/t/unit/utils/test_imports.py
+++ b/t/unit/utils/test_imports.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from contextlib import contextmanager
+from unittest.mock import Mock, call, patch
 
 import pytest
 
@@ -16,7 +17,7 @@ from mode.utils.imports import (
     smart_import,
     symbol_by_name,
 )
-from mode.utils.mocks import Mock, call, mask_module, patch
+from mode.utils.mocks import mask_module
 
 
 class test_FactoryMapping:

--- a/t/unit/utils/test_logging.py
+++ b/t/unit/utils/test_logging.py
@@ -1,5 +1,3 @@
-from typing import IO, Type
-
 import asyncio
 import io
 import logging
@@ -7,6 +5,7 @@ import sys
 import time
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+from typing import IO, Type
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
 import pytest

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -1,3 +1,7 @@
+import abc
+import collections.abc
+import pickle
+import sys
 import typing
 from typing import (
     AbstractSet,
@@ -15,12 +19,7 @@ from typing import (
     Tuple,
     Union,
 )
-from unittest.mock import Mock, ANY
-
-import abc
-import collections.abc
-import pickle
-import sys
+from unittest.mock import ANY, Mock
 
 import pytest
 

--- a/t/unit/utils/test_objects.py
+++ b/t/unit/utils/test_objects.py
@@ -34,6 +34,7 @@ from mode.utils.objects import (
     _ForwardRef_safe_eval,
     _remove_optional,
     _restore_from_keywords,
+    annotations,
     canoname,
     canonshortname,
     guess_polymorphic_type,
@@ -43,7 +44,6 @@ from mode.utils.objects import (
     label,
     qualname,
     remove_optional,
-    reveal_annotations,
     shortname,
 )
 
@@ -218,7 +218,7 @@ def test_annotations():
         baz: Union[List["X"], str]
         mas: int = 3
 
-    fields, defaults = reveal_annotations(
+    fields, defaults = annotations(
         X,
         globalns=globals(),
         localns=locals(),
@@ -242,7 +242,7 @@ def test_annotations__skip_classvar():
         baz: Union[List["X"], str]
         mas: int = 3
 
-    fields, defaults = reveal_annotations(
+    fields, defaults = annotations(
         X,
         globalns=globals(),
         localns=locals(),
@@ -263,7 +263,7 @@ def test_annotations__invalid_type():
         foo: List
 
     with pytest.raises(InvalidAnnotation):
-        reveal_annotations(
+        annotations(
             X,
             globalns=globals(),
             localns=locals(),
@@ -280,7 +280,7 @@ def test_annotations__no_local_ns_raises():
         bar: "Bar"
 
     with pytest.raises(NameError):
-        reveal_annotations(
+        annotations(
             X,
             globalns=None,
             localns=None,


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.fauststream.com/en/master/contributing.html).

## Description

Due to break change introduced in Python 3.11, [`wait()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) only accept scheduled tasks.

> Changed in version 3.11: Passing coroutine objects to `wait()` directly is forbidden.

In [services.py line 794](https://github.com/faust-streaming/mode/blob/d87d88362034b8663613c1502858234de7a5de93/mode/services.py#L794) of current master, two coroutines are passed into `wait()` function. So the program exits.

```
stopped = self._stopped.wait()
crashed = self._crashed.wait()
done, pending = await asyncio.wait(
    [stopped, crashed],
    return_when=asyncio.FIRST_COMPLETED,
    timeout=timeout,
)
```

This PR fixes #19.

This patch is enough to let `mode` successfully run under Python 3.11 except passing all test cases. Current tests of `mode` rely on its self defined `AsyncMock` which is already not working under py3.11, 
so there are still a lot of hard work to rewrite test cases to make everything looks good.