### PR TITLE
Improve CI job by removing cython option and adding new Python version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
+          cache-dependency-path: |
+            requirements/*.txt
+            requirements/**/*.txt
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Run linting checks"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Run Python tests
 
 on:
   push:
@@ -11,31 +11,26 @@ on:
 
 jobs:
   tests:
-    name: "Python ${{ matrix.python-version }}/Cython: ${{ matrix.use-cython }}"
+    name: "Run tests with Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
 
     strategy:
-      # Complete all jobs even if one fails, allows us to see
-      # for example if a test fails only when Cython is enabled
+      # Complete all jobs even if one fails
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        use-cython: ["true", "false"]
-    env:
-      USE_CYTHON: ${{ matrix.use-cython }}
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
       - uses: actions/checkout@v3
         with:
             fetch-depth: 0
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: "pip"
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Run linting checks"
         run: "scripts/check"
       - name: "Run tests"
         run: "scripts/tests"
-#      - name: "Enforce coverage"
-#        run: "scripts/coverage"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
       # Complete all jobs even if one fails
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ test-all: clean-pyc
 	$(TOX)
 
 test:
-	$(PYTHON) setup.py test
+	$(PYTEST) .
 
 cov:
 	$(PYTEST) -x --cov="$(PROJ)" --cov-report=html


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.fauststream.com/en/master/contributing.html).

## Description

`cython` is not used in `mode` and I add `3.11`/`3.12-dev` to matrix options.