### PR TITLE
Attempt to make Python tests pass for older versions

### DIFF
--- a/t/functional/utils/test_times.py
+++ b/t/functional/utils/test_times.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import monotonic
 
 import pytest

--- a/t/unit/test_services.py
+++ b/t/unit/test_services.py
@@ -367,10 +367,9 @@ class test_Service:
         service._stopped = Mock()
         service._crashed = Mock()
 
-        with (
-            patch("asyncio.wait", AsyncMock()) as wait,
-            patch("asyncio.ensure_future", Mock()) as ensure_future,
-        ):
+        with patch("asyncio.wait", AsyncMock()) as wait, patch(
+            "asyncio.ensure_future", Mock()
+        ) as ensure_future:
             f1 = Mock()
             f2 = Mock()
             f3 = Mock()
@@ -592,10 +591,9 @@ class test_Service:
 
     @pytest.mark.asyncio
     async def test_wait_many(self, *, service):
-        with (
-            patch("asyncio.wait", AsyncMock()) as wait,
-            patch("asyncio.ensure_future", Mock()) as ensure_future,
-        ):
+        with patch("asyncio.wait", AsyncMock()) as wait, patch(
+            "asyncio.ensure_future", Mock()
+        ) as ensure_future:
             service._wait_one = AsyncMock()
             m1 = AsyncMock()
             m2 = AsyncMock()

--- a/t/unit/test_supervisors.py
+++ b/t/unit/test_supervisors.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 

--- a/t/unit/utils/test_logging.py
+++ b/t/unit/utils/test_logging.py
@@ -2,10 +2,8 @@ import asyncio
 import io
 import logging
 import sys
-import time
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
-from typing import IO, Type
+from typing import IO
 from unittest.mock import ANY, AsyncMock, Mock, call, patch
 
 import pytest


### PR DESCRIPTION
If we can't get things working for 3.7+3.8, let's just end support for those versions. `mode-streaming` doesn't get many changes made anyways, so it'd be harmless.
