### PR TITLE
Stick with python 3.8 for docs builds for now

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v4
+      with:
+          python-version: "3.8"
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo


### PR DESCRIPTION
We need to use 3.8 to build docs for now until we figure out why 3.10 is broken. See https://github.com/faust-streaming/mode/actions/runs/3528608389/jobs/5918892063 for future reference.