### PR TITLE
Revert sleep time to 1.1 from 2.0

### DIFF
--- a/mode/threads.py
+++ b/mode/threads.py
@@ -181,7 +181,7 @@ class ServiceThread(Service):
 
     async def _keepalive2(self) -> None:
         while not self.should_stop:
-            await self.sleep(2.0)
+            await self.sleep(1.1)
             if self.last_wakeup_at:
                 if monotonic() - self.last_wakeup_at > 3.0:
                     self.log.error("Thread keepalive is not responding...")


### PR DESCRIPTION
Apparently there's a hardcoded value of `1.2` in https://github.com/faust-streaming/mode/blob/17c5d2996e4706baa37b18bd8fa03687409120ad/mode/timers.py#L13 so we may have made a terrible mistake.