### PR TITLE
fix: service class trying to get event loop on init

### DIFF
--- a/mode/services.py
+++ b/mode/services.py
@@ -596,16 +596,16 @@ class Service(ServiceBase, ServiceCallbacks):
         super().__init__(loop=self._loop)
 
     def _new_started_event(self) -> Event:
-        return Event(loop=self.loop)
+        return Event(loop=self._loop)
 
     def _new_stopped_event(self) -> Event:
-        return Event(loop=self.loop)
+        return Event(loop=self._loop)
 
     def _new_shutdown_event(self) -> Event:
-        return Event(loop=self.loop)
+        return Event(loop=self._loop)
 
     def _new_crashed_event(self) -> Event:
-        return Event(loop=self.loop)
+        return Event(loop=self._loop)
 
     async def transition_with(
         self, flag: str, fut: Awaitable, *args: Any, **kwargs: Any


### PR DESCRIPTION
The `_new_*_event` methods on the `Service` class were calling the `loop` property instead of using the `_loop` attribute, the property tried to fetch the current thread's event loop which caused [some odd issues](#61), this fix delays that until the event loop is actually needed (lazy loading).

This fixes #61
