### PR TITLE
fix(release): build and publish the sdist, harden publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
     types: [created]
     branches:
       - 'master'
+  # Manual re-publish/backfill: run from a tag to rebuild and upload any
+  # files missing on PyPI for that version (skip-existing keeps the rest).
+  workflow_dispatch:
 
 jobs:
   build:
@@ -28,18 +31,22 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
+          name: dist-packages
           path: 'dist/*'
+          if-no-files-found: error
 
   upload_pypi:
     name: Upload packages
     needs: ['build']
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'release' && github.event.action == 'created'
+    if: >-
+      (github.event_name == 'release' && github.event.action == 'created')
+      || github.event_name == 'workflow_dispatch'
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: dist-packages
           path: dist
 
       - name: Publish package to PyPI
@@ -47,3 +54,4 @@ jobs:
         with:
           user: '__token__'
           password: '${{ secrets.PYPI_API_TOKEN }}'
+          skip-existing: true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,5 @@
 
 set -x
 
-python3 -m build . --wheel
+python3 -m build .
 twine check dist/*


### PR DESCRIPTION
## Description

Releases 0.4.0 and 0.4.1 shipped to PyPI with **no source distribution** — only the universal wheel (verify: `https://pypi.org/pypi/mode-streaming/0.4.1/json` lists a single `bdist_wheel`). The cause is `scripts/build.sh` running `python3 -m build . --wheel`, which never builds an sdist.

Changes:

- `scripts/build.sh`: drop `--wheel` so `python -m build` produces both the sdist and the wheel. Verified locally: both artifacts build and pass `twine check`.
- `.github/workflows/publish.yml` hardening:
  - explicit artifact name (`dist-packages`) on upload/download instead of the implicit default
  - `if-no-files-found: error` so an empty `dist/` fails the build instead of silently publishing nothing
  - `skip-existing: true` on the PyPI publish step so re-runs are idempotent
  - `workflow_dispatch` trigger (publish gate widened accordingly) so the workflow can be run manually from a tag to backfill files missing from an already-published version

After this merges, running the workflow manually from tags `0.4.0` / `0.4.1` will backfill their missing sdists (`skip-existing` keeps the wheels already on the index), and future releases ship complete from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_