### PR TITLE
Support Python 3.14: stop relying on implicit event-loop creation

### DIFF
--- a/mode/loop/_gevent_loop.py
+++ b/mode/loop/_gevent_loop.py
@@ -1,9 +1,10 @@
 """Gevent loop customizations."""
 
-import asyncio
 from typing import Any
 
 import gevent.core
+
+from mode.utils.loops import get_event_loop
 
 
 class Loop(gevent.core.loop):  # type: ignore
@@ -13,8 +14,6 @@ class Loop(gevent.core.loop):  # type: ignore
 
     def run_callback(self, *args: Any, **kwargs: Any) -> None:
         if self._aioloop_loop is None:
-            self._aioloop_loop = (
-                asyncio.get_event_loop_policy().get_event_loop()
-            )
+            self._aioloop_loop = get_event_loop()
         gevent.spawn_later(0.0, self._aioloop_loop._run_once)  # type: ignore
         super().run_callback(*args, **kwargs)

--- a/mode/loop/gevent.py
+++ b/mode/loop/gevent.py
@@ -5,6 +5,8 @@ import os
 import warnings
 from typing import Optional, cast
 
+from mode.utils.loops import get_event_loop
+
 os.environ["GEVENT_LOOP"] = "mode.loop._gevent_loop.Loop"
 try:
     import gevent
@@ -59,4 +61,4 @@ class Policy(asyncio_gevent.EventLoopPolicy):  # type: ignore
 
 policy = Policy()
 asyncio.set_event_loop_policy(policy)
-loop = asyncio.get_event_loop_policy().get_event_loop()
+loop = get_event_loop()

--- a/mode/services.py
+++ b/mode/services.py
@@ -24,6 +24,8 @@ from time import monotonic, perf_counter
 from types import TracebackType
 from typing import Any, Callable, ClassVar, NamedTuple, Optional, Union, cast
 
+from mode.utils.loops import get_event_loop
+
 from .timers import Timer
 from .types import DiagT, ServiceT
 from .utils.cron import secs_for_next
@@ -136,7 +138,7 @@ class ServiceBase(ServiceT):
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         if self._loop is None:
-            self._loop = asyncio.get_event_loop_policy().get_event_loop()
+            self._loop = get_event_loop()
         return self._loop
 
     @loop.setter

--- a/mode/threads.py
+++ b/mode/threads.py
@@ -16,6 +16,8 @@ from collections.abc import Awaitable
 from time import monotonic
 from typing import Any, Callable, NamedTuple, Optional
 
+from mode.utils.loops import get_event_loop
+
 from .services import Service
 from .utils.futures import (
     maybe_async,
@@ -102,15 +104,11 @@ class ServiceThread(Service):
         **kwargs: Any,
     ) -> None:
         # cannot share loop between threads, so create a new one
-        assert asyncio.get_event_loop_policy().get_event_loop()
+        assert get_event_loop()
         if executor is not None:
             raise NotImplementedError("executor argument no longer supported")
-        self.parent_loop = (
-            loop or asyncio.get_event_loop_policy().get_event_loop()
-        )
-        self.thread_loop = (
-            thread_loop or asyncio.get_event_loop_policy().new_event_loop()
-        )
+        self.parent_loop = loop or get_event_loop()
+        self.thread_loop = thread_loop or asyncio.new_event_loop()
         self._thread_started = Event(loop=self.parent_loop)
         if Worker is not None:
             self.Worker = Worker
@@ -193,10 +191,7 @@ class ServiceThread(Service):
 
     async def crash(self, exc: BaseException) -> None:
         # <- .start() will raise
-        if (
-            asyncio.get_event_loop_policy().get_event_loop()
-            is self.parent_loop
-        ):
+        if get_event_loop() is self.parent_loop:
             maybe_set_exception(self._thread_running, exc)
         else:
             self.parent_loop.call_soon_threadsafe(

--- a/mode/utils/futures.py
+++ b/mode/utils/futures.py
@@ -4,6 +4,8 @@ import asyncio
 from inspect import isawaitable
 from typing import Any, Callable, NoReturn, Optional, Union
 
+from mode.utils.loops import get_event_loop
+
 # These used to be here, now moved to .queues
 from .queues import FlowControlEvent, FlowControlQueue  # noqa: F401
 
@@ -122,9 +124,7 @@ def done_future(
     result: Any = None, *, loop: Optional[asyncio.AbstractEventLoop] = None
 ) -> asyncio.Future:
     """Return `asyncio.Future` that is already evaluated."""
-    f = (
-        loop or asyncio.get_event_loop_policy().get_event_loop()
-    ).create_future()
+    f = (loop or get_event_loop()).create_future()
     f.set_result(result)
     return f
 

--- a/mode/utils/locks.py
+++ b/mode/utils/locks.py
@@ -9,6 +9,8 @@ import asyncio
 from collections import deque
 from typing import Optional
 
+from mode.utils.loops import get_event_loop
+
 
 class Event:
     """Asynchronous equivalent to threading.Event.
@@ -83,5 +85,5 @@ class Event:
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         if self._loop is None:
-            self._loop = asyncio.get_event_loop_policy().get_event_loop()
+            self._loop = get_event_loop()
         return self._loop

--- a/mode/utils/logging.py
+++ b/mode/utils/logging.py
@@ -33,6 +33,8 @@ from typing import (
 
 import colorlog
 
+from mode.utils.loops import get_event_loop
+
 from .futures import all_tasks, current_task
 from .locals import LocalStack
 from .text import title
@@ -556,7 +558,7 @@ def cry(
         thread = tmap.get(tid)
         if thread:
             if thread.ident == current_thread.ident:
-                loop = asyncio.get_event_loop_policy().get_event_loop()
+                loop = get_event_loop()
             else:
                 loop = getattr(thread, "loop", None)
             print(f"THREAD {thread.name}", file=file)
@@ -689,7 +691,7 @@ class flight_recorder(AbstractContextManager, LogSeverityMixin):
         self.id = next(self._id_source)
         self.logger = logger
         self.timeout = want_seconds(timeout)
-        self.loop = loop or asyncio.get_event_loop_policy().get_event_loop()
+        self.loop = loop or get_event_loop()
         self.started_at_date = None
         self.enabled_by = None
         self.exit_stack = ExitStack()

--- a/mode/utils/loops.py
+++ b/mode/utils/loops.py
@@ -3,7 +3,34 @@
 import asyncio
 from typing import Any, Callable, Optional
 
-__all__ = ["call_asap", "clone_loop"]
+__all__ = ["call_asap", "clone_loop", "get_event_loop"]
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    """Return the current event loop, creating one if necessary.
+
+    :func:`asyncio.get_event_loop` used to create and register an event loop
+    for the main thread when none was set.  That implicit behaviour was
+    deprecated in Python 3.10 and removed in Python 3.12/3.14, where both
+    :func:`asyncio.get_event_loop` and
+    ``asyncio.get_event_loop_policy().get_event_loop()`` raise
+    :exc:`RuntimeError` when there is no current event loop.
+
+    Mode accesses ``Service.loop`` (and other helpers) outside of a running
+    loop -- e.g. at import time, when agents/services are declared at module
+    level -- so it needs the historical "get or create" semantics.  This
+    restores them in a way that works across Python 3.9-3.14.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
 
 
 def _is_unix_loop(loop: asyncio.AbstractEventLoop) -> bool:

--- a/tests/unit/utils/test_loops.py
+++ b/tests/unit/utils/test_loops.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from mode.utils.loops import get_event_loop
+
+
+def test_get_event_loop__returns_running_loop_when_running():
+    async def main():
+        return get_event_loop()
+
+    running = asyncio.new_event_loop()
+    try:
+        got = running.run_until_complete(main())
+        assert got is running
+    finally:
+        running.close()
+
+
+def test_get_event_loop__reuses_current_loop_when_set():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        assert get_event_loop() is loop
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def test_get_event_loop__creates_loop_when_none_set():
+    # Emulates Python 3.14, where asyncio.get_event_loop() no longer creates
+    # a loop implicitly and raises RuntimeError instead.
+    asyncio.set_event_loop(None)
+    loop = get_event_loop()
+    try:
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+        assert asyncio.get_event_loop() is loop
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+def test_get_event_loop__is_idempotent_without_running_loop():
+    asyncio.set_event_loop(None)
+    first = get_event_loop()
+    try:
+        assert get_event_loop() is first
+    finally:
+        asyncio.set_event_loop(None)
+        first.close()


### PR DESCRIPTION
## Description

Python 3.14 removed the implicit creation of an event loop for the main
thread by `asyncio.get_event_loop()` / `get_event_loop_policy().get_event_loop()`;
they now raise `RuntimeError` when no current loop is set. Mode resolves
`Service.loop` outside of a running loop (e.g. at import time, when services
and agents are declared at module scope), which broke imports on 3.14 —
for example faust's `@app.agent()` at module level.

Adds a `get_event_loop()` helper in `mode.utils.loops` that restores the
historical get-or-create semantics across Python 3.9–3.14 (running loop →
thread's current loop → create + register), and routes every
`get_event_loop_policy().get_event_loop()` call site through it. New unit
tests cover the running / current / absent-loop paths. No behaviour change on
3.9–3.13.

Verified: full test suite passes on Python 3.11 and 3.13 (735 passed each), ruff clean, and `Service()` instantiation with no current event loop set now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_