### PR TITLE
fix(release): use a pinned Python and current packaging for twine check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,15 @@ jobs:
             fetch-depth: 0
 
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
       - name: Install build dependencies
-        run: pip install build twine
+        # --upgrade packaging: the system interpreter satisfies twine's floor
+        # with packaging 24.0, which predates Metadata-Version 2.4 / PEP 639
+        # License-File support and fails `twine check` on wheels built by
+        # setuptools >= 77.
+        run: pip install --upgrade build twine packaging
 
       - name: 'Build package'
         run: scripts/build.sh


### PR DESCRIPTION
## Description

The 0.5.0 release build failed at `twine check` with:

```
InvalidDistribution: Invalid distribution metadata: unrecognized or
malformed field 'license-file'
```

`setup-python` ran without a `python-version`, so the job used the runner's system interpreter, where Ubuntu's `dist-packages` `packaging` 24.0 already satisfied twine's `packaging>=24.0` floor and was never upgraded. `packaging` 24.0 predates Metadata-Version 2.4 / PEP 639 `License-File` support (added in `packaging` 24.2), so it rejects wheels built by setuptools ≥ 77. Reproduced locally with twine 6.2.0 + packaging 24.0 (fails) vs. twine 6.2.0 + current packaging (passes).

Pin `setup-python` to 3.13 (isolated tool-cache interpreter, no apt `dist-packages` leakage) and explicitly upgrade `packaging` alongside `build` and `twine`.

## Follow-up needed after merge

The `0.5.0` tag/release currently points at pre-fix master and never published to PyPI (the job died before the publish step). Once this merges, delete the `0.5.0` release + tag and recreate it on the new master head so the release event re-fires with the fixed workflow. `skip-existing` on the publish step makes this safe even if anything partial was uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_