### PR TITLE
Fix local_annotations() ignoring the stop= MRO boundary

### DIFF
--- a/mode/utils/objects.py
+++ b/mode/utils/objects.py
@@ -28,7 +28,6 @@ from typing import (
     cast,
     get_args,
     get_origin,
-    get_type_hints,
 )
 
 try:
@@ -364,9 +363,19 @@ def local_annotations(
     globalns: Optional[dict[str, Any]] = None,
     localns: Optional[dict[str, Any]] = None,
 ) -> Iterable[tuple[str, type]]:
-    d = get_type_hints(
-        cls, globalns if globalns is not None else _get_globalns(cls), localns
-    )
+    # NOTE: Must only consider annotations defined directly on `cls`, not
+    # inherited ones. `annotations()` (the caller) already walks the MRO
+    # itself via `iter_mro_reversed(cls, stop=stop)` and calls
+    # `local_annotations` once per class in that bounded range, so callers
+    # can exclude base classes at/above `stop` (e.g. faust.Record excludes
+    # its internal ModelT/Model bases this way). Using
+    # `typing.get_type_hints(cls, ...)` here defeats that: it always merges
+    # annotations from the *entire* real MRO regardless of `stop`, so a
+    # non-ClassVar annotation on an excluded base (e.g.
+    # `ModelT.__evaluated_fields__`) would leak back in as if it were a
+    # field of every subclass. String/ForwardRef annotations are still
+    # resolved below, per value, via `_resolve_refs`/`eval_type`.
+    d = cls.__annotations__
     return _resolve_refs(
         d,
         globalns if globalns is not None else _get_globalns(cls),

--- a/mode/utils/objects.py
+++ b/mode/utils/objects.py
@@ -38,14 +38,6 @@ except ImportError:
         return t
 
 
-try:
-    from typing import _type_check  # type: ignore
-except ImportError:
-
-    def _type_check(arg, msg, is_argument=True, module=None):  # type: ignore
-        return arg
-
-
 def _is_class_var(typ):
     # Works for typing.ClassVar and types.GenericAlias (Python 3.9+)
     origin = getattr(typ, "__origin__", None)
@@ -463,35 +455,20 @@ def eval_type(
     alias_types = alias_types or {}
     if isinstance(typ, str):
         typ = ForwardRef(typ)
-    if isinstance(typ, ForwardRef):
-        typ = _ForwardRef_safe_eval(typ, globalns, localns)
+    # `typing._eval_type` (imported above as `_eval_type`) already resolves
+    # ForwardRef instances directly -- it is the same stdlib function
+    # `typing.get_type_hints()` itself relies on, so it always matches
+    # whatever internal ForwardRef implementation the running interpreter
+    # has (this previously went through a hand-rolled evaluator here that
+    # poked at ForwardRef's private __forward_evaluated__/__forward_code__/
+    # __forward_value__ attributes as a workaround for Python 3.6/3.7; those
+    # attributes are not part of any stable API and are no longer present at
+    # all on Python 3.14's ForwardRef, which raised AttributeError. mode's
+    # floor is Python 3.9, well past the versions that workaround targeted).
     typ = _eval_type(typ, globalns, localns)
     if typ in invalid_types:
         raise InvalidAnnotation(typ)
     return alias_types.get(typ, typ)
-
-
-def _ForwardRef_safe_eval(
-    ref: ForwardRef,
-    globalns: Optional[dict[str, Any]] = None,
-    localns: Optional[dict[str, Any]] = None,
-) -> type:
-    # On 3.6/3.7 ForwardRef._evaluate crashes if str references ClassVar
-    if not ref.__forward_evaluated__:
-        if globalns is None and localns is None:
-            globalns = localns = {}
-        elif globalns is None:
-            globalns = localns
-        elif localns is None:
-            localns = globalns
-        val = eval(ref.__forward_code__, globalns, localns)  # noqa: S307
-        if not _is_class_var(val):
-            val = _type_check(
-                val, "Forward references must evaluate to types."
-            )
-        ref.__forward_value__ = val
-        ref.__forward_evaluated__ = True
-    return ref.__forward_value__
 
 
 def iter_mro_reversed(cls: type, stop: type) -> Iterable[type]:

--- a/mode/utils/objects.py
+++ b/mode/utils/objects.py
@@ -52,6 +52,33 @@ def _is_class_var(typ):
     return origin is ClassVar
 
 
+if sys.version_info >= (3, 10):
+    from inspect import get_annotations as _own_annotations
+else:
+
+    def _own_annotations(
+        cls: type,
+        *,
+        globals: Optional[dict] = None,
+        locals: Optional[dict] = None,
+        eval_str: bool = False,
+    ) -> dict:
+        """Backport of :func:`inspect.get_annotations` for Python 3.9.
+
+        Returns only the annotations declared directly in ``cls.__dict__``,
+        never inherited ones -- matching the 3.10+ stdlib function this
+        shadows, which is what makes it safe to use per-class inside a
+        bounded MRO walk (see ``local_annotations`` below).
+        """
+        ann = cls.__dict__.get("__annotations__", {})
+        if eval_str:
+            ann = {
+                k: (eval(v, globals, locals) if isinstance(v, str) else v)  # noqa: S307
+                for k, v in ann.items()
+            }
+        return dict(ann)
+
+
 def _get_globalns(cls):
     # Get the global namespace for a class
     module = sys.modules.get(cls.__module__)
@@ -373,9 +400,21 @@ def local_annotations(
     # annotations from the *entire* real MRO regardless of `stop`, so a
     # non-ClassVar annotation on an excluded base (e.g.
     # `ModelT.__evaluated_fields__`) would leak back in as if it were a
-    # field of every subclass. String/ForwardRef annotations are still
-    # resolved below, per value, via `_resolve_refs`/`eval_type`.
-    d = cls.__annotations__
+    # field of every subclass.
+    #
+    # Plain `cls.__annotations__` attribute access is *not* safe for this
+    # either: on Python < 3.10 it falls back to an inherited base's
+    # `__annotations__` via normal MRO lookup when `cls` itself has none of
+    # its own (re-introducing the same kind of leak), and on Python 3.14+
+    # (PEP 649, deferred evaluation of annotations) direct `__annotations__`
+    # access on a class can behave unreliably -- the stdlib explicitly
+    # recommends `inspect.get_annotations()` instead, which reads only
+    # `cls.__dict__["__annotations__"]` (own annotations, no MRO fallback)
+    # and is written to handle PEP 649 correctly. `_own_annotations` here is
+    # that function, with a same-behavior backport for 3.9. String/ForwardRef
+    # annotations are still resolved below, per value, via
+    # `_resolve_refs`/`eval_type`.
+    d = _own_annotations(cls)
     return _resolve_refs(
         d,
         globalns if globalns is not None else _get_globalns(cls),

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -251,6 +251,30 @@ def test_annotations__no_local_ns_raises():
         annotations(X, globalns=None, localns=None)
 
 
+def test_annotations__stop_excludes_base_above_stop():
+    # Regression test: a non-ClassVar annotation on a base class *above*
+    # `stop` must not leak into the fields of a subclass, even though
+    # Python's typing.get_type_hints() (which local_annotations() must NOT
+    # use directly) would normally merge annotations across the whole real
+    # MRO regardless of any `stop` boundary.
+    class Base:
+        # Deliberately not ClassVar, mirroring faust ModelT.__evaluated_fields__.
+        internal: int = 0
+
+    class Middle(Base):
+        pass
+
+    class Leaf(Middle):
+        foo: int
+
+    fields, _ = annotations(
+        Leaf, stop=Middle, globalns=globals(), localns=locals()
+    )
+
+    assert "internal" not in fields
+    assert fields == {"foo": int}
+
+
 @pytest.mark.parametrize(
     "input,expected",
     [

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -178,43 +178,6 @@ def test_eval_type():
     assert eval_type("typing.List") == list  # noqa: E721
 
 
-def test_annotations__TEMP_debug_314():
-    import inspect
-
-    from mode.utils.objects import local_annotations
-
-    class X:
-        Foo: ClassVar[int] = 3
-        foo: "int"
-        bar: list["X"]
-        baz: Union[list["X"], str]
-        mas: int = 3
-
-    print("=== TEMP DEBUG 314 START ===")
-    print(
-        "cls_dict_ann       =",
-        repr(X.__dict__.get("__annotations__", "<MISSING-KEY>")),
-    )
-    print("attr_ann           =", repr(X.__annotations__))
-    print("get_annotations()  =", repr(inspect.get_annotations(X)))
-    print(
-        "get_annotations(eval_str=True) =",
-        repr(
-            inspect.get_annotations(
-                X, eval_str=True, globals=globals(), locals=locals()
-            )
-        ),
-    )
-    print("has___annotate__   =", hasattr(X, "__annotate__"))
-    print("__annotate__       =", repr(getattr(X, "__annotate__", None)))
-    print(
-        "local_annotations()=",
-        list(local_annotations(X, globalns=globals(), localns=locals())),
-    )
-    print("=== TEMP DEBUG 314 END ===")
-    pytest.fail("see captured stdout above")
-
-
 def test_annotations():
     class X:
         Foo: ClassVar[int] = 3

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -178,6 +178,37 @@ def test_eval_type():
     assert eval_type("typing.List") == list  # noqa: E721
 
 
+def test_annotations__TEMP_debug_314():
+    import inspect
+
+    from mode.utils.objects import local_annotations
+
+    class X:
+        Foo: ClassVar[int] = 3
+        foo: "int"
+        bar: list["X"]
+        baz: Union[list["X"], str]
+        mas: int = 3
+
+    print("=== TEMP DEBUG 314 START ===")
+    print("cls_dict_ann       =", repr(X.__dict__.get("__annotations__", "<MISSING-KEY>")))
+    print("attr_ann           =", repr(X.__annotations__))
+    print("get_annotations()  =", repr(inspect.get_annotations(X)))
+    print(
+        "get_annotations(eval_str=True) =",
+        repr(
+            inspect.get_annotations(
+                X, eval_str=True, globals=globals(), locals=locals()
+            )
+        ),
+    )
+    print("has___annotate__   =", hasattr(X, "__annotate__"))
+    print("__annotate__       =", repr(getattr(X, "__annotate__", None)))
+    print("local_annotations()=", list(local_annotations(X, globalns=globals(), localns=locals())))
+    print("=== TEMP DEBUG 314 END ===")
+    assert False, "see captured stdout above"
+
+
 def test_annotations():
     class X:
         Foo: ClassVar[int] = 3

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -206,7 +206,7 @@ def test_annotations__TEMP_debug_314():
     print("__annotate__       =", repr(getattr(X, "__annotate__", None)))
     print("local_annotations()=", list(local_annotations(X, globalns=globals(), localns=locals())))
     print("=== TEMP DEBUG 314 END ===")
-    assert False, "see captured stdout above"
+    pytest.fail("see captured stdout above")
 
 
 def test_annotations():

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -191,7 +191,10 @@ def test_annotations__TEMP_debug_314():
         mas: int = 3
 
     print("=== TEMP DEBUG 314 START ===")
-    print("cls_dict_ann       =", repr(X.__dict__.get("__annotations__", "<MISSING-KEY>")))
+    print(
+        "cls_dict_ann       =",
+        repr(X.__dict__.get("__annotations__", "<MISSING-KEY>")),
+    )
     print("attr_ann           =", repr(X.__annotations__))
     print("get_annotations()  =", repr(inspect.get_annotations(X)))
     print(
@@ -204,7 +207,10 @@ def test_annotations__TEMP_debug_314():
     )
     print("has___annotate__   =", hasattr(X, "__annotate__"))
     print("__annotate__       =", repr(getattr(X, "__annotate__", None)))
-    print("local_annotations()=", list(local_annotations(X, globalns=globals(), localns=locals())))
+    print(
+        "local_annotations()=",
+        list(local_annotations(X, globalns=globals(), localns=locals())),
+    )
     print("=== TEMP DEBUG 314 END ===")
     pytest.fail("see captured stdout above")
 


### PR DESCRIPTION
## Description

**Severity: breaks every `faust.Record` subclass constructor**, on every supported Python version — introduced by `e8d0a96` ("Support Python 3.13, drop Python 3.8"), currently blocking essentially all `faust-streaming/faust` CI.

```pycon
>>> import faust
>>> class Foo(faust.Record):
...     x: int
>>> Foo(x=1)
TypeError: __outer__.<locals>.__init__() missing 1 required positional argument: '__evaluated_fields__'
```

### Root cause #1 — `local_annotations()` ignoring the `stop=` MRO boundary

`annotations(cls, stop=...)` is documented to only consider fields declared between `stop` (exclusive) and `cls` (inclusive) in the MRO — callers rely on this to exclude internal bookkeeping attributes declared on a base class above `stop` (e.g. `faust.Record` passes `stop=Record` to exclude its internal `ModelT`/`Model` bases).

`local_annotations(cls)` resolved fields via `typing.get_type_hints(cls, ...)`, which always merges annotations from the *entire* real MRO regardless of `stop`. `iter_mro_reversed()` correctly bounds which *classes* get scanned, but `get_type_hints()` on any one of them independently re-walks the full ancestry, defeating the boundary. A non-`ClassVar` annotation on an excluded base — `faust.types.models.ModelT.__evaluated_fields__`, sitting right next to the correctly-filtered `ClassVar`-marked `__is_model__` — leaked back in as if it were a real field of every subclass, becoming a required positional parameter of every generated `__init__`.

**Fix:** `local_annotations()` now reads a class's own annotations via `inspect.get_annotations(cls)` (with a same-behavior backport for the 3.9 floor, since it was added in 3.10) instead of `get_type_hints`. This has no MRO fallback at all — strictly safer than the boundary get_type_hints() defeated.

### Root cause #2 — found via CI's actual Python 3.14 runner, not in this repo's control

Fixing #1 alone still crashed on Python 3.14 CI (a *different*, pre-existing latent bug this investigation surfaced): every field with a string-quoted annotation (e.g. `foo: "int"`) crashed with

```
AttributeError: 'ForwardRef' object has no attribute '__forward_evaluated__'.
```

`eval_type()` unconditionally routed every `ForwardRef` through `_ForwardRef_safe_eval()`, a hand-rolled evaluator reading `ForwardRef`'s private `__forward_evaluated__`/`__forward_code__`/`__forward_value__` attributes — by its own comment, a workaround for "3.6/3.7". mode's floor is Python 3.9, so this path was already dead weight for the versions it targeted, and Python 3.14 no longer exposes those attributes on `ForwardRef` at all, turning dead weight into a hard crash.

**Fix:** removed `_ForwardRef_safe_eval` (and the now-unused `_type_check` import). `typing._eval_type` — already called unconditionally right below the removed code — resolves `ForwardRef` instances directly and is the same stdlib function `typing.get_type_hints()` itself relies on, so it always matches whichever `ForwardRef` implementation the running interpreter actually has.

No 3.14 interpreter was available in this development environment (network policy blocks python-build-standalone/deadsnakes, no Docker daemon) — root cause #2 was diagnosed from real 3.14 CI output via a temporary diagnostic test (since removed), not guessed.

### Verification

- Added `test_annotations__stop_excludes_base_above_stop`, a regression test mirroring the `ModelT` scenario (root cause #1). Confirmed it fails with the pre-fix code and passes with the fix.
- Existing `test_annotations`, `test_annotations__skip_classvar`, and `test_annotations__no_local_ns_raises` already exercise string-quoted forward refs, so they cover root cause #2 without needing a new dedicated test.
- Full suite: 736 passed on Python 3.11 and 3.13, ruff clean.
- Cross-checked against a real `faust-streaming/faust` checkout with this fixed `mode` installed in place of the PyPI release: `Foo(x=1, name="hi")` instantiates correctly and `Foo._options.fields` has no `__evaluated_fields__` leak.
- CI's Python 3.14 job is the authoritative check for root cause #2, since no local 3.14 interpreter was available.

### Known residual issue — not fully resolved by this PR

Independent of both fixes above, faust's `tests/functional/test_models.py` still has an estimated ~11 failures involving related/polymorphic model field coercion (`test_custom_coercion`, `test_polymorphic_fields`, `test_Secret`, `test_default_no_blessed_key`, and others), down from *total collection failure* for the whole file beforehand. This looks like a narrower, separate issue — possibly other fallout from `e8d0a96` — and needs further investigation before considering faust's model test suite fully green again. (Not independently re-verified in this environment due to an unrelated pytest-version/conftest mismatch when running faust's own suite here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd