### PR TITLE
Fix two annotation-resolution regressions from the 3.13 rewrite

### DIFF
--- a/mode/utils/objects.py
+++ b/mode/utils/objects.py
@@ -366,11 +366,18 @@ def annotations(
                 )
             )
 
-    # Normalize all field types for forward refs
-    normalized_fields = {
-        k: _normalize_forwardref(v) for k, v in fields.items()
-    }
-    return normalized_fields, defaults
+    # NOTE: Return the resolved field types as-is. `_resolve_refs`/`eval_type`
+    # above already turned string/ForwardRef annotations into real types, so
+    # nothing further is needed here. Do NOT run `_normalize_forwardref` over
+    # the result: it rewrites any type whose ``__qualname__`` contains
+    # "<locals>" (i.e. every class defined inside a function) down to a bare
+    # ``__name__`` *string*, destroying the actual class object. Callers such
+    # as faust.Record rely on identity of the returned types (e.g. matching a
+    # field type against a custom coercion mapping), which silently breaks
+    # when the type is replaced by its name string. `_normalize_forwardref`
+    # remains available as a comparison helper for callers/tests that want a
+    # canonical, hashable-by-name form.
+    return fields, defaults
 
 
 def local_annotations(
@@ -453,6 +460,7 @@ def eval_type(
     """
     invalid_types = invalid_types or set()
     alias_types = alias_types or {}
+    original_str = typ if isinstance(typ, str) else None
     if isinstance(typ, str):
         typ = ForwardRef(typ)
     # `typing._eval_type` (imported above as `_eval_type`) already resolves
@@ -465,7 +473,30 @@ def eval_type(
     # attributes are not part of any stable API and are no longer present at
     # all on Python 3.14's ForwardRef, which raised AttributeError. mode's
     # floor is Python 3.9, well past the versions that workaround targeted).
-    typ = _eval_type(typ, globalns, localns)
+    if isinstance(typ, ForwardRef):
+        try:
+            typ = _eval_type(typ, globalns, localns)
+        except TypeError:
+            # `_eval_type` runs the forward ref through `typing._type_check`,
+            # which rejects `ClassVar[...]` with "is not valid as type
+            # argument". But a *string* ClassVar annotation is legitimate --
+            # `from __future__ import annotations` stringizes every
+            # annotation, ClassVars included -- and callers (see
+            # `_resolve_refs` + `skip_classvar`) still want to see it so they
+            # can drop it. Evaluate the forward arg directly and accept it
+            # when it is a ClassVar; otherwise re-raise the real error.
+            src = (
+                original_str
+                if original_str is not None
+                else typ.__forward_arg__
+            )
+            evaluated = eval(src, globalns, localns)  # noqa: S307
+            if _is_class_var(evaluated):
+                typ = evaluated
+            else:
+                raise
+    else:
+        typ = _eval_type(typ, globalns, localns)
     if typ in invalid_types:
         raise InvalidAnnotation(typ)
     return alias_types.get(typ, typ)

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -275,6 +275,38 @@ def test_annotations__stop_excludes_base_above_stop():
     assert fields == {"foo": int}
 
 
+def test_annotations__preserves_function_local_class_identity():
+    # Regression test: a field annotated with a class defined inside a
+    # function (``__qualname__`` contains "<locals>") must be returned as the
+    # actual class object, not rewritten to its bare name string. Callers
+    # such as faust.Record match a field's resolved type by identity against
+    # a coercion mapping, which silently breaks if the type is replaced by a
+    # string.
+    class Local:
+        value: int
+
+    class Holder:
+        item: Local
+
+    fields, _ = annotations(Holder, globalns=globals(), localns=locals())
+
+    assert fields["item"] is Local
+    assert not isinstance(fields["item"], str)
+
+
+def test_eval_type__string_classvar_is_not_rejected():
+    # Regression test: a *string* ClassVar annotation (as produced by
+    # `from __future__ import annotations`) must not raise. Passing the
+    # forward ref straight to typing._eval_type runs typing._type_check,
+    # which rejects ClassVar[...] with "is not valid as type argument".
+    from typing import ClassVar as _ClassVar
+
+    result = eval_type(
+        "ClassVar[int]", globalns={"ClassVar": _ClassVar}, localns={}
+    )
+    assert result == _ClassVar[int]
+
+
 @pytest.mark.parametrize(
     "input,expected",
     [


### PR DESCRIPTION
## Description

`0.5.0`/`0.5.1` were yanked. The "Support Python 3.13" annotation rework introduced **two independent regressions** that break every `faust.Record` downstream (they don't reproduce in mode's own tests, only downstream, which is why they slipped through both prior fixes).

### Regression 1 — `annotations()` stringifies function-local classes

`annotations()` post-processed its result through `_normalize_forwardref`, which rewrites any type whose `__qualname__` contains `"<locals>"` (i.e. every class defined inside a function) down to a bare `__name__` **string**. `faust.Record` matches a field's resolved type **by identity** against its coercion mapping, so once the type becomes a string, coercion/polymorphic handling silently stops working for function-local model field types — which is exactly how faust's `test_models.py` defines its models. `_resolve_refs`/`eval_type` already resolve string/ForwardRef annotations to real types before this point, so the normalization pass was redundant for resolution and actively destructive.

**Fix:** return `fields` directly (as 0.4.x did). `_normalize_forwardref` remains available as a comparison helper.

### Regression 2 — `eval_type` rejects string `ClassVar`

The 3.14 `ForwardRef`-compat rewrite calls stdlib `typing._eval_type` directly on the `ForwardRef`, which runs `typing._type_check` — and that rejects `ClassVar[...]` with `TypeError: ... is not valid as type argument`. A *string* `ClassVar` annotation is legitimate (`from __future__ import annotations` stringizes every annotation, ClassVars included), so any Record with a quoted ClassVar — or any Record at all under future-annotations — raised at class creation.

**Fix:** catch that `TypeError`, evaluate the forward arg directly, and accept the result when it's a `ClassVar` (callers drop it via `skip_classvar`); otherwise re-raise the real error.

### Verification

- Added `test_annotations__preserves_function_local_class_identity` and `test_eval_type__string_classvar_is_not_rejected`. Confirmed both fail against the genuine pre-fix code (checked out from the parent commit) with the exact errors described above, and pass with the fix.
- mode's own suite: 738 passed on Python 3.11 and 3.13, ruff clean.
- Cross-checked against a real `faust-streaming/faust` checkout with this fixed `mode` installed in place of the PyPI release, in a dedicated venv matching faust's own pinned test requirements: `tests/functional/test_models.py` — 89 passed, 0 failed (previously total collection failure). Full faust `tests/unit` + `tests/functional`: **2128 passed, 32 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_