### PR TITLE
ci: promote Python 3.14 from experimental to a required test leg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,8 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         experimental: [ false ]
-        include:
-          - python-version: "~3.14.0-0"
-            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Operating System :: POSIX",


### PR DESCRIPTION
## Description

The 3.14 matrix entry had `continue-on-error: true`, so its result was discarded regardless of pass/fail — CI reported green even when it was red. This is almost certainly why the three Python 3.14 regressions fixed this cycle (`get_event_loop()`'s implicit-creation removal in #72, `local_annotations()`'s MRO leak in #74, `eval_type`'s `ForwardRef`/`ClassVar` crashes in #75) shipped in `0.5.0` and `0.5.1` — both since yanked — without mode's own CI ever blocking on them.

`0.5.2` is verified working end-to-end on 3.14 (mode's own suite and a full `faust-streaming/faust` cross-check, both green — see #75/#76). This moves 3.14 out of the `include`/experimental block and into the regular matrix so it's a full, required leg like every other supported version, matching the required 3.14 legs already added on the faust side (faust-streaming/faust#691). The `"~3.14.0-0"` prerelease version-range syntax is also no longer needed now that 3.14 has stable releases (the CI runner was already resolving it to `3.14.6`).

Also declares Python 3.14 in `pyproject.toml`'s trove classifiers, so it's reflected on PyPI (the README's version badge reads this automatically) and in the built package metadata — confirmed via a local build + `twine check`.

## Verification

- `.github/workflows/tests.yml` parses as valid YAML.
- Local build with the updated `pyproject.toml`: `Programming Language :: Python :: 3.14` present in the wheel's `METADATA`, `twine check` passes on both sdist and wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgnKFtXZbCjXNoVNWa5JLd)_